### PR TITLE
fixed bug with scroll in CodeEditor when it became larger than parent

### DIFF
--- a/app/src/main/java/org/stepic/droid/code/ui/CodeEditor.kt
+++ b/app/src/main/java/org/stepic/droid/code/ui/CodeEditor.kt
@@ -207,6 +207,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     override fun afterTextChanged(editable: Editable) {
         lines = text.toString().lines()
         highlightPublisher.onNext(editable)
+        requestLayout()
     }
 
     override fun beforeTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, count: Int) {}


### PR DESCRIPTION
**YouTrack task**:

**Description List**:
* Fixed bug with a scroll in `CodeEditor` when it's content becomes larger than the parent. The reason of this bug was that height of `CodeEditor` wasn't properly invalidated on its content update.