### PR TITLE
fix work with nulls in rxjava

### DIFF
--- a/app/src/main/java/org/stepic/droid/code/ui/CodeEditor.kt
+++ b/app/src/main/java/org/stepic/droid/code/ui/CodeEditor.kt
@@ -27,10 +27,7 @@ import org.stepic.droid.code.highlight.ParserContainer
 import org.stepic.droid.code.highlight.syntaxhighlight.ParseResult
 import org.stepic.droid.code.highlight.themes.CodeTheme
 import org.stepic.droid.code.highlight.themes.Presets
-import org.stepic.droid.util.DpPixelsHelper
-import org.stepic.droid.util.RxEmpty
-import org.stepic.droid.util.filterNotNull
-import org.stepic.droid.util.substringOrNull
+import org.stepic.droid.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -120,9 +117,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 highlightPublisher
                         .debounce(INPUT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
                         .map {
-                            parserContainer.prettifyParser?.parse(lang, it.toString())
+                            RxOptional(parserContainer.prettifyParser?.parse(lang, it.toString()))
                         }
-                        .filterNotNull()
+                        .unwrapOptional()
                         .subscribe(spanPublisher::onNext)
         )
 

--- a/app/src/main/java/org/stepic/droid/util/RxUtil.kt
+++ b/app/src/main/java/org/stepic/droid/util/RxUtil.kt
@@ -4,6 +4,10 @@ import io.reactivex.Observable
 
 enum class RxEmpty { INSTANCE }
 
-@Suppress("UNCHECKED_CAST")
-fun <T> Observable<T?>.filterNotNull(): Observable<T> =
-        this.filter { it != null } as Observable<T>
+data class RxOptional<out T> (val value: T?) {
+    fun <R> map(f: (T) -> R?) =
+            RxOptional(value?.let(f))
+}
+
+fun <T> Observable<RxOptional<T>>.unwrapOptional(): Observable<T> =
+        this.filter { it.value != null }.map { it.value }


### PR DESCRIPTION
**YouTrack task**: [#](https://vyahhi.myjetbrains.com/youtrack/issue/)

**Description List**:
* RxJava throws a `NullPointerException` on contact with `null` so `filterNotNull` won't work. http://rxjava-doc.readthedocs.io/en/latest/What%27s-different-in-2.0/#nulls 
There is a `RxOptional` class to work with nullable references.
