### PR TITLE
Default ActionBar height

### DIFF
--- a/app/src/main/res/layout/view_centered_toolbar.xml
+++ b/app/src/main/res/layout/view_centered_toolbar.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/centeredToolbar"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/action_bar_height"
+    android:layout_height="?attr/actionBarSize"
     android:layout_gravity="center"
     app:titleTextAppearance="@style/StepikToolbarTextAppearance">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -143,6 +143,4 @@
     <dimen name="popup_window_padding">8dp</dimen>
     <dimen name="popup_text_padding">12dp</dimen>
     <dimen name="popup_arrow_size">16dp</dimen>
-
-    <dimen name="action_bar_height">60dp</dimen>
 </resources>


### PR DESCRIPTION
**YouTrack task**:

**Description List**:
* `ActionBar` had a fixed height of `60dp` that makes menu icons look decentralized. Now it's height returned back to default `?attr/actionBarSize`.