### PR TITLE
fix newlines in code quiz samples

### DIFF
--- a/app/src/main/java/org/stepic/droid/ui/fragments/CodeStepFragment.kt
+++ b/app/src/main/java/org/stepic/droid/ui/fragments/CodeStepFragment.kt
@@ -227,12 +227,11 @@ class CodeStepFragment : StepAttemptFragment(),
             }
             stringBuilder.append(getString(R.string.sample_input, index + 1))
             stringBuilder.append(newLine)
-            stringBuilder.append(parcelableStringList[0])
+            stringBuilder.append(parcelableStringList[0].replace("\n", newLine))
             stringBuilder.append(newLine)
             stringBuilder.append(getString(R.string.sample_output, index + 1))
             stringBuilder.append(newLine)
-            stringBuilder.append(parcelableStringList[1])
-
+            stringBuilder.append(parcelableStringList[1].replace("\n", newLine))
         }
         val samplesString = textResolver.fromHtml(stringBuilder.toString())
         codeQuizSamples.text = samplesString


### PR DESCRIPTION
**YouTrack task**: [#APPS-1643](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1643)

**Description List**:
* Replace `\n` character with `<br>` in code quiz samples
<img src="https://user-images.githubusercontent.com/3856523/32901330-9c79612e-cb00-11e7-8be2-7ccc8f36018e.png" width="300" />