### PR TITLE
Feature/improve my courses loading

### DIFF
--- a/app/src/main/java/org/stepic/droid/analytic/Analytic.java
+++ b/app/src/main/java/org/stepic/droid/analytic/Analytic.java
@@ -38,9 +38,6 @@ public interface Analytic {
         String EMPTY_COURSES_SHOWN = "fast_continue_empty_courses";
         String EMPTY_COURSES_CLICK = "fast_continue_empty_courses_click";
 
-        String NO_INTERNET_SHOWN = "fast_continue_no_internet";
-        String NO_INTERNET_CLICK = "fast_continue_no_internet_click";
-
         String AUTH_SHOWN = "fast_continue_auth";
         String AUTH_CLICK = "fast_continue_auth_click";
 

--- a/app/src/main/java/org/stepic/droid/core/FirstCoursePoster.kt
+++ b/app/src/main/java/org/stepic/droid/core/FirstCoursePoster.kt
@@ -1,0 +1,17 @@
+package org.stepic.droid.core
+
+import org.stepic.droid.di.course_list.CourseGeneralScope
+import org.stepic.droid.model.Course
+import org.stepic.droid.util.RxOptional
+import javax.inject.Inject
+
+@CourseGeneralScope
+class FirstCoursePoster
+@Inject
+constructor(
+        private val firstCourseSubjectHolder: FirstCourseSubjectHolder
+) {
+    fun postFirstCourse(course: Course?) {
+        firstCourseSubjectHolder.firstCourseSubject.onNext(RxOptional(course))
+    }
+}

--- a/app/src/main/java/org/stepic/droid/core/FirstCoursePoster.kt
+++ b/app/src/main/java/org/stepic/droid/core/FirstCoursePoster.kt
@@ -14,4 +14,10 @@ constructor(
     fun postFirstCourse(course: Course?) {
         firstCourseSubjectHolder.firstCourseSubject.onNext(RxOptional(course))
     }
+
+    fun postConnectionError() {
+        if (!firstCourseSubjectHolder.firstCourseSubject.hasValue()) {
+            firstCourseSubjectHolder.firstCourseSubject.onNext(RxOptional(null))
+        }
+    }
 }

--- a/app/src/main/java/org/stepic/droid/core/FirstCourseProvider.kt
+++ b/app/src/main/java/org/stepic/droid/core/FirstCourseProvider.kt
@@ -1,0 +1,14 @@
+package org.stepic.droid.core
+
+import io.reactivex.Observable
+import org.stepic.droid.di.course_list.CourseGeneralScope
+import org.stepic.droid.model.Course
+import org.stepic.droid.util.RxOptional
+import javax.inject.Inject
+
+@CourseGeneralScope
+class FirstCourseProvider
+@Inject
+constructor(private val firstCourseSubjectHolder: FirstCourseSubjectHolder) {
+    fun firstCourse(): Observable<RxOptional<Course>> = firstCourseSubjectHolder.firstCourseSubject
+}

--- a/app/src/main/java/org/stepic/droid/core/FirstCourseSubjectHolder.kt
+++ b/app/src/main/java/org/stepic/droid/core/FirstCourseSubjectHolder.kt
@@ -1,0 +1,15 @@
+package org.stepic.droid.core
+
+import io.reactivex.subjects.BehaviorSubject
+import org.stepic.droid.di.course_list.CourseGeneralScope
+import org.stepic.droid.model.Course
+import org.stepic.droid.util.RxOptional
+import javax.inject.Inject
+
+
+@CourseGeneralScope
+class FirstCourseSubjectHolder
+@Inject
+constructor() {
+    val firstCourseSubject = BehaviorSubject.create<RxOptional<Course>>()
+}

--- a/app/src/main/java/org/stepic/droid/core/presenters/FastContinuePresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/FastContinuePresenter.kt
@@ -1,0 +1,53 @@
+package org.stepic.droid.core.presenters
+
+import io.reactivex.Scheduler
+import io.reactivex.disposables.Disposable
+import org.stepic.droid.core.FirstCourseProvider
+import org.stepic.droid.core.presenters.contracts.FastContinueView
+import org.stepic.droid.di.course_list.CourseGeneralScope
+import org.stepic.droid.di.qualifiers.MainScheduler
+import org.stepic.droid.preferences.SharedPreferenceHelper
+import javax.inject.Inject
+
+@CourseGeneralScope
+class FastContinuePresenter
+@Inject
+constructor(
+        private val sharedPreferenceHelper: SharedPreferenceHelper,
+        private val firstCourseProvider: FirstCourseProvider,
+        @MainScheduler
+        private val mainScheduler: Scheduler
+) : PresenterBase<FastContinueView>() {
+
+    private var disposable: Disposable? = null
+
+    fun onCreated() {
+        if (sharedPreferenceHelper.authResponseFromStore != null) {
+            view?.onLoading()
+            subscribeToFirstCourse()
+        } else {
+            view?.onAnonymous()
+        }
+    }
+
+    private fun subscribeToFirstCourse() {
+        disposable = firstCourseProvider
+                .firstCourse()
+                .observeOn(mainScheduler)
+                .subscribe {
+                    val course = it.value
+                    if (course == null) {
+                        view?.onEmptyCourse()
+                    } else {
+                        view?.onShowCourse(course)
+                    }
+                }
+    }
+
+    override fun detachView(view: FastContinueView) {
+        disposable?.dispose()
+        super.detachView(view)
+    }
+
+
+}

--- a/app/src/main/java/org/stepic/droid/core/presenters/PersistentCourseListPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/PersistentCourseListPresenter.kt
@@ -144,8 +144,8 @@ class PersistentCourseListPresenter
                 //this lock need for not saving enrolled courses to database after user click logout
                 RWLocks.ClearEnrollmentsLock.writeLock().lock()
                 if (sharedPreferenceHelper.authResponseFromStore != null || courseType == Table.featured) {
-                    if (isRefreshing && currentPage.get() == 2) {
-                        if (courseType == Table.featured) {
+                    if (isRefreshing) {
+                        if (courseType == Table.featured && currentPage.get() == 2) {
                             databaseFacade.dropFeaturedCourses()
                         } else if (courseType == Table.enrolled) {
                             databaseFacade.dropEnrolledCourses()

--- a/app/src/main/java/org/stepic/droid/core/presenters/PersistentCourseListPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/PersistentCourseListPresenter.kt
@@ -4,6 +4,7 @@ import android.support.annotation.WorkerThread
 import org.stepic.droid.concurrency.MainHandler
 import org.stepic.droid.concurrency.SingleThreadExecutor
 import org.stepic.droid.core.FilterApplicator
+import org.stepic.droid.core.FirstCoursePoster
 import org.stepic.droid.core.earlystreak.contract.EarlyStreakPoster
 import org.stepic.droid.core.presenters.contracts.CoursesView
 import org.stepic.droid.di.course_list.CourseListScope
@@ -31,7 +32,8 @@ class PersistentCourseListPresenter
         private val api: Api,
         private val filterApplicator: FilterApplicator,
         private val sharedPreferenceHelper: SharedPreferenceHelper,
-        private val earlyStreakPoster: EarlyStreakPoster
+        private val earlyStreakPoster: EarlyStreakPoster,
+        private val firstCoursePoster: FirstCoursePoster
 ) : PresenterBase<CoursesView>() {
 
     companion object {
@@ -113,6 +115,7 @@ class PersistentCourseListPresenter
 
             if (coursesFromInternet == null) {
                 mainHandler.post {
+                    firstCoursePoster.postConnectionError()
                     view?.showConnectionProblem()
                 }
                 break
@@ -167,6 +170,7 @@ class PersistentCourseListPresenter
                 //try to load next in loop
             } else {
                 mainHandler.post {
+                    postFirstCourse(courseType, coursesForShow)
                     if (coursesForShow.isEmpty()) {
                         isEmptyCourses.set(true)
                         view?.showEmptyCourses()
@@ -194,8 +198,19 @@ class PersistentCourseListPresenter
         if (coursesForShow.isNotEmpty()) {
             mainHandler.post {
                 view?.showCourses(coursesForShow)
+                postFirstCourse(courseType, coursesForShow)
             }
         }
+    }
+
+    private fun postFirstCourse(courseType: Table, coursesForShow: List<Course>) {
+        if (courseType != Table.enrolled) {
+            return
+        }
+        val course = coursesForShow.find {
+            it.isActive && it.sections?.isNotEmpty() ?: false
+        }
+        firstCoursePoster.postFirstCourse(course)
     }
 
     private fun handleCoursesWithType(courses: List<Course>, courseType: Table?): List<Course> =

--- a/app/src/main/java/org/stepic/droid/core/presenters/contracts/FastContinueView.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/contracts/FastContinueView.kt
@@ -1,0 +1,14 @@
+package org.stepic.droid.core.presenters.contracts
+
+import org.stepic.droid.model.Course
+
+interface FastContinueView {
+
+    fun onLoading()
+
+    fun onAnonymous()
+
+    fun onEmptyCourse()
+
+    fun onShowCourse(course: Course)
+}

--- a/app/src/main/java/org/stepic/droid/ui/fragments/FastContinueFragment.kt
+++ b/app/src/main/java/org/stepic/droid/ui/fragments/FastContinueFragment.kt
@@ -37,7 +37,9 @@ import javax.inject.Inject
 class FastContinueFragment : FragmentBase(),
         ContinueCourseView,
         DroppingListener,
-        JoiningListener, FastContinueView {
+        JoiningListener,
+        FastContinueView {
+
     companion object {
         fun newInstance(): FastContinueFragment = FastContinueFragment()
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -509,7 +509,7 @@
     <string name="name">Имя</string>
 
     <string name="sign_up_with_email_suffix">" с e-mail"</string>
-    <string name="placeholder_explore_courses">Откройте для себя другие бесплатные онлайн курсы</string>
+    <string name="placeholder_explore_courses">Откройте для себя бесплатные онлайн курсы</string>
     <string name="placeholder_login">Войдите и начните учиться прямо сейчас</string>
 
     <string name="courses_carousel_my_courses_empty">Запишитесь на курсы и они будут показаны здесь</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,7 +516,7 @@
 
     <string name="sign_up_with_email_suffix">" with e-mail"</string>
 
-    <string name="placeholder_explore_courses">Discover new open free online courses. Tap to find</string>
+    <string name="placeholder_explore_courses">Discover free online courses. Tap to find</string>
     <string name="placeholder_login">Login and start learning right now</string>
 
     <string name="courses_carousel_my_courses_empty">Enroll for free courses and they will be here</string>


### PR DESCRIPTION
**YouTrack task**: [#APPS-1680](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1680)

**Description List**:
* fix bug, when my courses were not dropped for user with 1 or 3+ pages.
* double course dropping removes course from list, but "no internet" message is shown (it should be fixed in future, because it is out of task scope)
* avoid requesting courses for fast continue view (now my courses are requested 1 time)
* post 1st course via `BehaviorSubject` from `PersistentCourseListPresenter.kt`
* `null` first course means that courses are empty or no courses in database + no internet
* remove "No internet" state for FastContinueFragment