### PR TITLE
fix schedule notifications in UTC timezone

### DIFF
--- a/app/src/main/java/org/stepic/droid/notifications/LocalReminderImpl.kt
+++ b/app/src/main/java/org/stepic/droid/notifications/LocalReminderImpl.kt
@@ -166,7 +166,7 @@ class LocalReminderImpl
 
                 if (sharedPreferenceHelper.isEverLogged) return@execute
 
-                val now = DateTimeHelper.nowLocal()
+                val now = DateTimeHelper.nowUtc()
                 val oldTimestamp = sharedPreferenceHelper.registrationRemindTimestamp
 
                 val scheduleMillis = if (now < oldTimestamp) {


### PR DESCRIPTION
**YouTrack task**: [#APPS-1635](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1635)

**Description List**:
* `AlarmManager` alarms should be set in UTC timezone but they were set in the local timezone that causes bugs on devices with negative timezone.

