### PR TITLE
fix Android 4.4 LaTeX

### DIFF
--- a/app/src/main/java/org/stepic/droid/util/HtmlHelper.java
+++ b/app/src/main/java/org/stepic/droid/util/HtmlHelper.java
@@ -188,6 +188,10 @@ public class HtmlHelper {
     public static final String HORIZONTAL_SCROLL_LISTENER = "scrollListener";
     private static final String HORIZONTAL_SCROLL_STYLE;
 
+    // this block is needed to force render of WebView
+    private static final String MIN_RENDERED_BLOCK =
+            "<div style=\"height: 1px; overflow: hidden; width: 1px; background-color: rgba(0,0,0,0.001); pointer-events: none; user-select: none; -webkit-user-select: none;\"></div>";
+
     static {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             HORIZONTAL_SCROLL_STYLE =
@@ -199,6 +203,17 @@ public class HtmlHelper {
                     "</style>\n";
         } else {
             HORIZONTAL_SCROLL_STYLE = "";
+        }
+
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
+            POST_BODY =
+                    MIN_RENDERED_BLOCK +
+                    "</body>\n" +
+                    "</html>";
+        } else {
+            POST_BODY =
+                    "</body>\n" +
+                    "</html>";
         }
     }
 
@@ -264,8 +279,7 @@ public class HtmlHelper {
             + "\nimg { max-width: 100%%; }"
             + "</style>\n";
 
-    private static final String POST_BODY = "</body>\n" +
-            "</html>";
+    private static final String POST_BODY;
 
     private static final String MathJaxScript =
             "<script type=\"text/x-mathjax-config\">\n" +


### PR DESCRIPTION
**YouTrack task**: [#APPS-1669](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1669)

**Description List**:
* if there is the only LaTeX formula on a web page on Android 4.4 `WebView` won't render it. There are two options to fix this problem: 
  * the first one is to set `layerType` of `WebView` to `LAYER_TYPE_SOFTWARE` but we can't use this approach due to large `WebView` in steps that can't fit into software buffer,
  * the second one is to add small non-transparent block to force render of `WebView`
  
  we used the second one for now

