### PR TITLE
Feature/support new auth error type

### DIFF
--- a/app/src/main/java/org/stepic/droid/core/LoginFailType.kt
+++ b/app/src/main/java/org/stepic/droid/core/LoginFailType.kt
@@ -4,5 +4,8 @@ enum class LoginFailType {
     connectionProblem,
     tooManyAttempts,
     emailAlreadyUsed,
-    emailPasswordInvalid
+    emailPasswordInvalid,
+
+    emailNotProvidedBySocial,
+    unknownError
 }

--- a/app/src/main/java/org/stepic/droid/core/LoginFailType.kt
+++ b/app/src/main/java/org/stepic/droid/core/LoginFailType.kt
@@ -1,11 +1,11 @@
 package org.stepic.droid.core
 
 enum class LoginFailType {
-    connectionProblem,
-    tooManyAttempts,
-    emailAlreadyUsed,
-    emailPasswordInvalid,
+    CONNECTION_PROBLEM,
+    TOO_MANY_ATTEMPTS,
+    EMAIL_ALREADY_USED,
+    EMAIL_PASSWORD_INVALID,
 
-    emailNotProvidedBySocial,
-    unknownError
+    EMAIL_NOT_PROVIDED_BY_SOCIAL,
+    UNKNOWN_ERROR
 }

--- a/app/src/main/java/org/stepic/droid/core/presenters/LoginPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/LoginPresenter.kt
@@ -69,10 +69,10 @@ class LoginPresenter
                     } else {
                         analytic.reportEvent(Analytic.Error.UNPREDICTABLE_LOGIN_RESULT)
                         //successful result, but body is not correct
-                        onFail(LoginFailType.connectionProblem)
+                        onFail(LoginFailType.CONNECTION_PROBLEM)
                     }
                 } else if (response.code() == 429) {
-                    onFail(LoginFailType.tooManyAttempts)
+                    onFail(LoginFailType.TOO_MANY_ATTEMPTS)
                 } else if (response.code() == 401 && type == Type.social) {
                     val rawErrorMessage = response.errorBody()?.string()
                     val socialAuthError = rawErrorMessage?.toObject<SocialAuthError>()
@@ -82,19 +82,19 @@ class LoginPresenter
                             mainHandler.post {
                                 view?.onSocialLoginWithExistingEmail(socialAuthError.email ?: "")
                             }
-                            LoginFailType.emailAlreadyUsed
+                            LoginFailType.EMAIL_ALREADY_USED
                         }
 
-                        AppConstants.ERROR_SOCIAL_AUTH_WITHOUT_EMAIL -> LoginFailType.emailNotProvidedBySocial
-                        else -> LoginFailType.unknownError
+                        AppConstants.ERROR_SOCIAL_AUTH_WITHOUT_EMAIL -> LoginFailType.EMAIL_NOT_PROVIDED_BY_SOCIAL
+                        else -> LoginFailType.UNKNOWN_ERROR
                     }
 
                     onFail(failType)
                 } else {
-                    onFail(LoginFailType.emailPasswordInvalid)
+                    onFail(LoginFailType.EMAIL_PASSWORD_INVALID)
                 }
             } catch (ex: Exception) {
-                onFail(LoginFailType.connectionProblem)
+                onFail(LoginFailType.CONNECTION_PROBLEM)
             }
         }
     }

--- a/app/src/main/java/org/stepic/droid/core/presenters/LoginPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/LoginPresenter.kt
@@ -77,15 +77,19 @@ class LoginPresenter
                     val rawErrorMessage = response.errorBody()?.string()
                     val socialAuthError = rawErrorMessage?.toObject<SocialAuthError>()
 
-                    if (socialAuthError?.email != null && socialAuthError.error == AppConstants.ERROR_SOCIAL_AUTH_WITH_EXISTING_EMAIL) {
-                        mainHandler.post {
-                            view?.onSocialLoginWithExistingEmail(socialAuthError.email)
+                    val failType = when(socialAuthError?.error) {
+                        AppConstants.ERROR_SOCIAL_AUTH_WITH_EXISTING_EMAIL -> {
+                            mainHandler.post {
+                                view?.onSocialLoginWithExistingEmail(socialAuthError.email ?: "")
+                            }
+                            LoginFailType.emailAlreadyUsed
                         }
-                        onFail(LoginFailType.emailAlreadyUsed)
-                    } else {
-                        onFail(LoginFailType.emailAlreadyUsed, rawErrorMessage)
+
+                        AppConstants.ERROR_SOCIAL_AUTH_WITHOUT_EMAIL -> LoginFailType.emailNotProvidedBySocial
+                        else -> LoginFailType.unknownError
                     }
 
+                    onFail(failType)
                 } else {
                     onFail(LoginFailType.emailPasswordInvalid)
                 }

--- a/app/src/main/java/org/stepic/droid/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/stepic/droid/ui/activities/LoginActivity.kt
@@ -206,7 +206,7 @@ class LoginActivity : SmartLockActivityBase(), LoginView {
         loginErrorMessage.text = getMessageFor(type)
         loginErrorMessage.visibility = View.VISIBLE
 
-        if (type == LoginFailType.emailAlreadyUsed || type == LoginFailType.emailPasswordInvalid) {
+        if (type == LoginFailType.EMAIL_ALREADY_USED || type == LoginFailType.EMAIL_PASSWORD_INVALID) {
             loginForm.isEnabled = false
             loginButton.isEnabled = false
         }

--- a/app/src/main/java/org/stepic/droid/util/AppConstants.java
+++ b/app/src/main/java/org/stepic/droid/util/AppConstants.java
@@ -11,6 +11,7 @@ public class AppConstants {
     public static final String VIDEO_EXTENSION = ".mp4";
 
     public static final String ERROR_SOCIAL_AUTH_WITH_EXISTING_EMAIL = "social_signup_with_existing_email";
+    public static final String ERROR_SOCIAL_AUTH_WITHOUT_EMAIL = "social_signup_without_email";
 
     public static final String KEY_EMAIL_BUNDLE = "email";
     public static final String KEY_COURSE_BUNDLE = "course";

--- a/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
+++ b/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
@@ -9,8 +9,10 @@ fun Context.getMessageFor(type: LoginFailType): String {
         return when (type) {
             LoginFailType.connectionProblem -> getString(R.string.connectionProblems)
             LoginFailType.emailAlreadyUsed -> getString(R.string.email_already_used)
+            LoginFailType.emailNotProvidedBySocial -> getString(R.string.email_not_provided_by_social)
             LoginFailType.tooManyAttempts -> getString(R.string.too_many_attempts)
             LoginFailType.emailPasswordInvalid -> getString(R.string.failLogin)
+            LoginFailType.unknownError -> getString(R.string.unknown_auth_error)
         }
     }
 }

--- a/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
+++ b/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
@@ -7,12 +7,12 @@ import org.stepic.droid.core.LoginFailType
 fun Context.getMessageFor(type: LoginFailType): String {
     with(resources) {
         return when (type) {
-            LoginFailType.connectionProblem -> getString(R.string.connectionProblems)
-            LoginFailType.emailAlreadyUsed -> getString(R.string.email_already_used)
-            LoginFailType.emailNotProvidedBySocial -> getString(R.string.email_not_provided_by_social)
-            LoginFailType.tooManyAttempts -> getString(R.string.too_many_attempts)
-            LoginFailType.emailPasswordInvalid -> getString(R.string.failLogin)
-            LoginFailType.unknownError -> getString(R.string.unknown_auth_error)
+            LoginFailType.CONNECTION_PROBLEM -> getString(R.string.connectionProblems)
+            LoginFailType.EMAIL_ALREADY_USED -> getString(R.string.email_already_used)
+            LoginFailType.EMAIL_NOT_PROVIDED_BY_SOCIAL -> getString(R.string.email_not_provided_by_social)
+            LoginFailType.TOO_MANY_ATTEMPTS -> getString(R.string.too_many_attempts)
+            LoginFailType.EMAIL_PASSWORD_INVALID -> getString(R.string.failLogin)
+            LoginFailType.UNKNOWN_ERROR -> getString(R.string.unknown_auth_error)
         }
     }
 }

--- a/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
+++ b/app/src/main/java/org/stepic/droid/util/LoginUtil.kt
@@ -8,11 +8,11 @@ fun Context.getMessageFor(type: LoginFailType): String {
     with(resources) {
         return when (type) {
             LoginFailType.CONNECTION_PROBLEM -> getString(R.string.connectionProblems)
-            LoginFailType.EMAIL_ALREADY_USED -> getString(R.string.email_already_used)
-            LoginFailType.EMAIL_NOT_PROVIDED_BY_SOCIAL -> getString(R.string.email_not_provided_by_social)
+            LoginFailType.EMAIL_ALREADY_USED -> getString(R.string.auth_error_email_already_used)
+            LoginFailType.EMAIL_NOT_PROVIDED_BY_SOCIAL -> getString(R.string.auth_error_email_not_provided_by_social)
             LoginFailType.TOO_MANY_ATTEMPTS -> getString(R.string.too_many_attempts)
-            LoginFailType.EMAIL_PASSWORD_INVALID -> getString(R.string.failLogin)
-            LoginFailType.UNKNOWN_ERROR -> getString(R.string.unknown_auth_error)
+            LoginFailType.EMAIL_PASSWORD_INVALID -> getString(R.string.auth_error_invalid_credentials)
+            LoginFailType.UNKNOWN_ERROR -> getString(R.string.auth_error_unknown)
         }
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -268,6 +268,8 @@
     <string name="are_you_sure_remove_comment_text">Если Вы выйдите, эта запись будет потеряна
     </string>
     <string name="email_already_used">Данный e-mail используется в другом аккаунте</string>
+    <string name="email_not_provided_by_social">Ошибка авторизации: в аккаунте социальной сети не указан email</string>
+    <string name="unknown_auth_error">Ошибка авторизации</string>
     <string name="go_to_the_next_lesson">Следующий урок</string>
     <string name="cant_show_next_step">Извините, следующий урок недоступен</string>
     <string name="previous_lesson">Предыдущий урок</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -63,7 +63,6 @@
     <string name="cancel">Отмена</string>
     <string name="save">Сохранить</string>
     <string name="select">Выбрать</string>
-    <string name="failLogin">E-mail адрес/пароль неверны</string>
     <string name="are_you_sure">Вы уверены?</string>
     <string name="deny">Отклонить</string>
     <string name="allow">Разрешить</string>
@@ -267,9 +266,12 @@
     <string name="empty_certificates">Пока вы не получили ни одного сертификата</string>
     <string name="are_you_sure_remove_comment_text">Если Вы выйдите, эта запись будет потеряна
     </string>
-    <string name="email_already_used">Данный e-mail используется в другом аккаунте</string>
-    <string name="email_not_provided_by_social">Ошибка авторизации: в аккаунте социальной сети не указан email</string>
-    <string name="unknown_auth_error">Ошибка авторизации</string>
+
+    <string name="auth_error_invalid_credentials">E-mail адрес/пароль неверны</string>
+    <string name="auth_error_email_already_used">Данный e-mail используется в другом аккаунте</string>
+    <string name="auth_error_email_not_provided_by_social">Ошибка авторизации: в аккаунте социальной сети не указан email</string>
+    <string name="auth_error_unknown">Ошибка авторизации</string>
+
     <string name="go_to_the_next_lesson">Следующий урок</string>
     <string name="cant_show_next_step">Извините, следующий урок недоступен</string>
     <string name="previous_lesson">Предыдущий урок</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,6 +284,8 @@
     <string name="empty_certificates">You don\'t have any certificates yet</string>
     <string name="are_you_sure_remove_comment_text">If you go back, your post will be lost</string>
     <string name="email_already_used">The e-mail is used for another account</string>
+    <string name="email_not_provided_by_social">Authorization error: email is not provided by social network</string>
+    <string name="unknown_auth_error">Authorization error</string>
     <string name="go_to_the_next_lesson">Next lesson</string>
     <string name="cant_show_next_step">Sorry, the next lesson is not available</string>
     <string name="cant_show_previous_step">Sorry, the previous lesson is not available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,6 @@
     <string name="cancel">Cancel</string>
     <string name="save">Save</string>
     <string name="select">Select</string>
-    <string name="failLogin">Login/password was incorrect</string>
     <string name="connectionProblems">Connection was lost</string>
     <string name="are_you_sure">Are you sure?</string>
     <string name="explain_permission">For caching the course and playing the video offline Stepik
@@ -283,9 +282,12 @@
     <string name="add_to_linkedin">Add to LinkedIn</string>
     <string name="empty_certificates">You don\'t have any certificates yet</string>
     <string name="are_you_sure_remove_comment_text">If you go back, your post will be lost</string>
-    <string name="email_already_used">The e-mail is used for another account</string>
-    <string name="email_not_provided_by_social">Authorization error: email is not provided by social network</string>
-    <string name="unknown_auth_error">Authorization error</string>
+
+    <string name="auth_error_invalid_credentials">Login/password was incorrect</string>
+    <string name="auth_error_email_already_used">The e-mail is used for another account</string>
+    <string name="auth_error_email_not_provided_by_social">Authorization error: email is not provided by social network</string>
+    <string name="auth_error_unknown">Authorization error</string>
+
     <string name="go_to_the_next_lesson">Next lesson</string>
     <string name="cant_show_next_step">Sorry, the next lesson is not available</string>
     <string name="cant_show_previous_step">Sorry, the previous lesson is not available</string>


### PR DESCRIPTION
**YouTrack task**: [#APPS-1933](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1933)

**Description List**:
* add support for a new auth error type `social_signup_without_email`
* fix bug when all social errors considered as `social_signup_with_existing_email`
* clean up naming of auth errors resources

