### PR TITLE
Hotfix/1.64.1

### DIFF
--- a/app/src/main/java/org/stepic/droid/jsonHelpers/adapters/UTCDateAdapter.kt
+++ b/app/src/main/java/org/stepic/droid/jsonHelpers/adapters/UTCDateAdapter.kt
@@ -12,6 +12,7 @@ class UTCDateAdapter: JsonSerializer<Date>, JsonDeserializer<Date> {
     companion object {
         private const val UTC_ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         private const val UTC_ISO_FORMAT_SIMPLE = "yyyy-MM-dd'T'HH:mm:ss"
+        private const val UTC_ISO_FORMAT_SIMPLE_LENGTH = UTC_ISO_FORMAT_SIMPLE.length - 2 // exclude 2 single quotes around T
 
         private fun createDateFormat(pattern: String) = SimpleDateFormat(pattern, Locale.getDefault()).apply {
             timeZone = TimeZone.getTimeZone("UTC")
@@ -26,7 +27,7 @@ class UTCDateAdapter: JsonSerializer<Date>, JsonDeserializer<Date> {
 
 
     override fun deserialize(jsonElement: JsonElement, typeOfT: Type?, context: JsonDeserializationContext?): Date = try {
-        deserializeDateFormat.parse(jsonElement.asString.take(UTC_ISO_FORMAT_SIMPLE.length))
+        deserializeDateFormat.parse(jsonElement.asString.take(UTC_ISO_FORMAT_SIMPLE_LENGTH))
     } catch (e: ParseException) {
         throw JsonParseException(e)
     }

--- a/app/src/main/java/org/stepic/droid/services/DeleteService.kt
+++ b/app/src/main/java/org/stepic/droid/services/DeleteService.kt
@@ -57,7 +57,7 @@ class DeleteService : IntentService("delete_service") {
                     removeFromDisk(lesson)
                 }
                 LoadService.LoadTypeKey.Step -> {
-                    val step = intent.getSerializableExtra(AppConstants.KEY_STEP_BUNDLE) as? Step
+                    val step = intent.getParcelableExtra<Step>(AppConstants.KEY_STEP_BUNDLE)
                     removeFromDisk(step)
                 }
             }

--- a/app/src/main/java/org/stepic/droid/storage/CleanManagerImpl.kt
+++ b/app/src/main/java/org/stepic/droid/storage/CleanManagerImpl.kt
@@ -8,7 +8,6 @@ import org.stepik.android.model.Step
 import org.stepic.droid.services.DeleteService
 import org.stepic.droid.services.LoadService
 import org.stepic.droid.util.AppConstants
-import java.io.Serializable
 import javax.inject.Inject
 
 class CleanManagerImpl @Inject constructor(private val context: Context) : CleanManager {
@@ -31,7 +30,7 @@ class CleanManagerImpl @Inject constructor(private val context: Context) : Clean
         val loadIntent = Intent(context, DeleteService::class.java)
 
         loadIntent.putExtra(AppConstants.KEY_LOAD_TYPE, LoadService.LoadTypeKey.Lesson)
-        loadIntent.putExtra(AppConstants.KEY_LESSON_BUNDLE, lesson as Parcelable)
+        loadIntent.putExtra(AppConstants.KEY_LESSON_BUNDLE, lesson)
 
         context.startService(loadIntent)
 
@@ -45,7 +44,7 @@ class CleanManagerImpl @Inject constructor(private val context: Context) : Clean
         val loadIntent = Intent(context, DeleteService::class.java)
 
         loadIntent.putExtra(AppConstants.KEY_LOAD_TYPE, LoadService.LoadTypeKey.Step)
-        loadIntent.putExtra(AppConstants.KEY_STEP_BUNDLE, step as Serializable)
+        loadIntent.putExtra(AppConstants.KEY_STEP_BUNDLE, step)
 
         context.startService(loadIntent)
     }

--- a/app/src/main/java/org/stepic/droid/storage/DownloadManagerImpl.java
+++ b/app/src/main/java/org/stepic/droid/storage/DownloadManagerImpl.java
@@ -35,7 +35,7 @@ public class DownloadManagerImpl implements IDownloadManager {
         Intent loadIntent = new Intent(App.Companion.getAppContext(), LoadService.class);
 
         loadIntent.putExtra(AppConstants.KEY_LOAD_TYPE, LoadService.LoadTypeKey.Lesson);
-        loadIntent.putExtra(AppConstants.KEY_LESSON_BUNDLE, (Parcelable) lesson);
+        loadIntent.putExtra(AppConstants.KEY_LESSON_BUNDLE, lesson);
 
         App.Companion.getAppContext().startService(loadIntent);
 

--- a/app/src/test/java/org/stepic/droid/jsonHelpers/adapters/UTCDateAdapterTest.kt
+++ b/app/src/test/java/org/stepic/droid/jsonHelpers/adapters/UTCDateAdapterTest.kt
@@ -16,4 +16,13 @@ class UTCDateAdapterTest {
         val wrapper = deadlines.toObject<DeadlinesWrapper>(gson)
         assertEquals(gson.toJson(wrapper), deadlines)
     }
+
+    @Test
+    fun dateDeserializationTest() {
+        val dateString = "2018-04-04T09:08:09.000Z"
+        val dateAdapter = UTCDateAdapter()
+
+        val date = dateAdapter.stringToDate(dateString)
+        assertEquals(1522832889000, date?.time)
+    }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext.versions = [
-        code                 : 1995,
-        name                 : '1.64',
+        code                 : 1996,
+        name                 : '1.64.1',
 
         minSdk               : 15,
         targetSdk            : 26,

--- a/model/src/main/java/org/stepik/android/model/Block.kt
+++ b/model/src/main/java/org/stepik/android/model/Block.kt
@@ -5,8 +5,6 @@ import android.os.Parcelable
 
 import org.stepik.android.model.code.CodeOptions
 
-import java.io.Serializable
-
 //more fields look at stepik.org/api/steps/14671
 class Block(
         val name: String? = null,
@@ -16,7 +14,7 @@ class Block(
         var cachedLocalVideo: Video? = null,
 
         val options: CodeOptions? = null
-) : Parcelable, Serializable {
+) : Parcelable {
     override fun describeContents(): Int = 0
 
     override fun writeToParcel(dest: Parcel, flags: Int) {

--- a/model/src/main/java/org/stepik/android/model/Lesson.kt
+++ b/model/src/main/java/org/stepik/android/model/Lesson.kt
@@ -4,7 +4,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import org.stepik.android.model.util.readBoolean
+import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
+import org.stepik.android.model.util.writeDate
 
 import java.io.Serializable
 import java.util.*
@@ -77,8 +79,8 @@ class Lesson(
         dest.writeBoolean(isPublic)
         dest.writeString(this.title)
         dest.writeString(this.slug)
-        dest.writeSerializable(this.createDate)
-        dest.writeSerializable(this.updateDate)
+        dest.writeDate(this.createDate)
+        dest.writeDate(this.updateDate)
         dest.writeString(this.learnersGroup)
         dest.writeString(this.teacherGroup)
         dest.writeString(this.coverUrl)
@@ -105,8 +107,8 @@ class Lesson(
                 parcel.readBoolean(),
                 parcel.readString(),
                 parcel.readString(),
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
+                parcel.readDate(),
+                parcel.readDate(),
                 parcel.readString(),
                 parcel.readString(),
                 parcel.readString(),

--- a/model/src/main/java/org/stepik/android/model/Lesson.kt
+++ b/model/src/main/java/org/stepik/android/model/Lesson.kt
@@ -8,7 +8,6 @@ import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
 import org.stepik.android.model.util.writeDate
 
-import java.io.Serializable
 import java.util.*
 
 class Lesson(
@@ -57,7 +56,7 @@ class Lesson(
         @SerializedName("time_to_complete")
         val timeToComplete: Long = 0
 
-) : Parcelable, Serializable, Progressable {
+) : Parcelable, Progressable {
 
     override fun describeContents(): Int = 0
 

--- a/model/src/main/java/org/stepik/android/model/Section.kt
+++ b/model/src/main/java/org/stepik/android/model/Section.kt
@@ -4,7 +4,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import org.stepik.android.model.util.readBoolean
+import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
+import org.stepik.android.model.util.writeDate
 
 import java.util.Date
 
@@ -60,12 +62,12 @@ data class Section(
         parcel.writeString(progress)
         parcel.writeString(title)
         parcel.writeString(slug)
-        parcel.writeSerializable(beginDate)
-        parcel.writeSerializable(endDate)
-        parcel.writeSerializable(softDeadline)
-        parcel.writeSerializable(hardDeadline)
-        parcel.writeSerializable(createDate)
-        parcel.writeSerializable(updateDate)
+        parcel.writeDate(beginDate)
+        parcel.writeDate(endDate)
+        parcel.writeDate(softDeadline)
+        parcel.writeDate(hardDeadline)
+        parcel.writeDate(createDate)
+        parcel.writeDate(updateDate)
         parcel.writeString(gradingPolicy)
         parcel.writeBoolean(isActive)
         parcel.writeParcelable(actions, flags)
@@ -89,12 +91,12 @@ data class Section(
                 parcel.readString(),
                 parcel.readString(),
                 parcel.readString(),
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
                 parcel.readString(),
                 parcel.readBoolean(),
                 parcel.readParcelable(Actions::class.java.classLoader),

--- a/model/src/main/java/org/stepik/android/model/Step.kt
+++ b/model/src/main/java/org/stepik/android/model/Step.kt
@@ -3,8 +3,7 @@ package org.stepik.android.model
 import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import org.stepik.android.model.util.readBoolean
-import org.stepik.android.model.util.writeBoolean
+import org.stepik.android.model.util.*
 
 import java.util.Date
 
@@ -48,41 +47,49 @@ data class Step(
         dest.writeLong(this.id)
         dest.writeLong(this.lesson)
         dest.writeLong(this.position)
-        dest.writeInt(this.discussionsCount)
-        dest.writeString(this.discussionProxy)
         dest.writeInt(this.status?.ordinal ?: -1)
         dest.writeParcelable(this.block, 0)
         dest.writeString(this.progress)
         dest.writeList(this.subscriptions)
+
         dest.writeLong(this.viewedBy)
         dest.writeLong(this.passedBy)
-        dest.writeSerializable(this.createDate)
-        dest.writeSerializable(this.updateDate)
+
+        dest.writeDate(this.createDate)
+        dest.writeDate(this.updateDate)
+
         dest.writeBoolean(isCached)
         dest.writeBoolean(isLoading)
         dest.writeBoolean(isCustomPassed)
         dest.writeParcelable(this.actions, flags)
+
+        dest.writeInt(this.discussionsCount)
+        dest.writeString(this.discussionProxy)
     }
 
     companion object CREATOR : Parcelable.Creator<Step> {
-        override fun createFromParcel(parcel: Parcel): Step? = Step(
-                id = parcel.readLong(),
-                lesson = parcel.readLong(),
-                position = parcel.readLong(),
-                discussionsCount = parcel.readInt(),
-                discussionProxy = parcel.readString(),
-                status = Status.values().getOrNull(parcel.readInt()),
-                block = parcel.readParcelable(Block::class.java.classLoader),
-                progress = parcel.readString(),
-                subscriptions = parcel.createStringArrayList(),
-                viewedBy = parcel.readLong(),
-                passedBy = parcel.readLong(),
-                createDate = parcel.readSerializable() as? Date,
-                updateDate = parcel.readSerializable() as? Date,
-                isCached = parcel.readBoolean(),
-                isLoading = parcel.readBoolean(),
-                isCustomPassed = parcel.readBoolean(),
-                actions = parcel.readParcelable(Actions::class.java.classLoader)
+        override fun createFromParcel(parcel: Parcel): Step = Step(
+                parcel.readLong(),
+                parcel.readLong(),
+                parcel.readLong(),
+                Status.values().getOrNull(parcel.readInt()),
+                parcel.readParcelable(Block::class.java.classLoader),
+                parcel.readString(),
+                parcel.createStringArrayList(),
+
+                parcel.readLong(),
+                parcel.readLong(),
+
+                parcel.readDate(),
+                parcel.readDate(),
+
+                parcel.readBoolean(),
+                parcel.readBoolean(),
+                parcel.readBoolean(),
+                parcel.readParcelable(Actions::class.java.classLoader),
+
+                parcel.readInt(),
+                parcel.readString()
         )
 
         override fun newArray(size: Int): Array<out Step?> = arrayOfNulls(size)

--- a/model/src/main/java/org/stepik/android/model/Unit.kt
+++ b/model/src/main/java/org/stepik/android/model/Unit.kt
@@ -8,7 +8,6 @@ import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
 import org.stepik.android.model.util.writeDate
 
-import java.io.Serializable
 import java.util.Date
 
 class Unit(
@@ -52,7 +51,7 @@ class Unit(
 
         @Deprecated("")
         var is_viewed_custom: Boolean = false
-) : Serializable, Parcelable, Progressable {
+) : Parcelable, Progressable {
 
     override fun describeContents(): Int = 0
 

--- a/model/src/main/java/org/stepik/android/model/Unit.kt
+++ b/model/src/main/java/org/stepik/android/model/Unit.kt
@@ -4,7 +4,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import org.stepik.android.model.util.readBoolean
+import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
+import org.stepik.android.model.util.writeDate
 
 import java.io.Serializable
 import java.util.Date
@@ -61,10 +63,10 @@ class Unit(
         dest.writeLongArray(this.assignments)
         dest.writeInt(this.position)
         dest.writeString(this.progress)
-        dest.writeSerializable(this.beginDate)
-        dest.writeSerializable(this.endDate)
-        dest.writeSerializable(this.softDeadline)
-        dest.writeSerializable(this.hardDeadline)
+        dest.writeDate(this.beginDate)
+        dest.writeDate(this.endDate)
+        dest.writeDate(this.softDeadline)
+        dest.writeDate(this.hardDeadline)
         dest.writeString(this.gradingPolicy)
         dest.writeString(this.beginDateSource)
         dest.writeString(this.endDateSource)
@@ -72,8 +74,8 @@ class Unit(
         dest.writeString(this.hardDeadlineSource)
         dest.writeString(this.gradingPolicySource)
         dest.writeBoolean(isActive)
-        dest.writeSerializable(this.createDate)
-        dest.writeSerializable(this.updateDate)
+        dest.writeDate(this.createDate)
+        dest.writeDate(this.updateDate)
         dest.writeBoolean(is_viewed_custom)
     }
 
@@ -85,10 +87,10 @@ class Unit(
                 parcel.createLongArray(),
                 parcel.readInt(),
                 parcel.readString(),
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
+                parcel.readDate(),
                 parcel.readString(),
                 parcel.readString(),
                 parcel.readString(),
@@ -96,8 +98,8 @@ class Unit(
                 parcel.readString(),
                 parcel.readString(),
                 parcel.readBoolean(),
-                parcel.readSerializable() as? Date,
-                parcel.readSerializable() as? Date,
+                parcel.readDate(),
+                parcel.readDate(),
                 parcel.readBoolean()
         )
 

--- a/model/src/main/java/org/stepik/android/model/comments/Comment.kt
+++ b/model/src/main/java/org/stepik/android/model/comments/Comment.kt
@@ -7,7 +7,9 @@ import com.google.gson.annotations.SerializedName
 import org.stepik.android.model.UserRole
 import org.stepik.android.model.Actions
 import org.stepik.android.model.util.readBoolean
+import org.stepik.android.model.util.readDate
 import org.stepik.android.model.util.writeBoolean
+import org.stepik.android.model.util.writeDate
 import java.util.Date
 
 data class Comment(
@@ -67,7 +69,7 @@ data class Comment(
                 parcel.readValue(Long::class.java.classLoader) as Long?,
                 parcel.readValue(Long::class.java.classLoader) as Long?,
                 UserRole.values().getOrNull(parcel.readInt()),
-                parcel.readSerializable() as? Date,
+                parcel.readDate(),
                 parcel.readString() ?: "",
                 parcel.readValue(Int::class.java.classLoader) as Int?,
                 parcel.readValue(Boolean::class.java.classLoader) as Boolean?,
@@ -98,7 +100,7 @@ data class Comment(
         dest.writeValue(parent)
         dest.writeValue(user)
         dest.writeInt(userRole?.ordinal ?: -1)
-        dest.writeSerializable(time)
+        dest.writeDate(time)
         dest.writeString(text)
         dest.writeValue(replyCount)
         dest.writeValue(isDeleted)

--- a/model/src/main/java/org/stepik/android/model/util/ParcelableExtensions.kt
+++ b/model/src/main/java/org/stepik/android/model/util/ParcelableExtensions.kt
@@ -2,6 +2,7 @@ package org.stepik.android.model.util
 
 import android.os.Parcel
 import android.os.Parcelable
+import java.util.*
 
 fun Parcel.writeBoolean(value: Boolean) =
         writeByte(if (value) 1 else 0)
@@ -43,3 +44,12 @@ fun <K : Parcelable, V : Parcelable> Parcel.readMapCustom(classLoaderKey: ClassL
 
 fun <V : Parcelable> Parcel.readMapCustomString(classLoaderValue: ClassLoader): Map<String, V> =
         readMap(Parcel::readString, getParcelableReader(classLoaderValue))
+
+
+internal const val NO_VALUE = -1L
+
+fun Parcel.writeDate(value: Date?) =
+        writeLong(value?.time ?: NO_VALUE)
+
+fun Parcel.readDate(): Date? =
+        readLong().takeIf { it != NO_VALUE }?.let(::Date)

--- a/model/src/test/java/org/stepik/android/model/StepTest.kt
+++ b/model/src/test/java/org/stepik/android/model/StepTest.kt
@@ -4,12 +4,19 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.stepik.android.model.util.assertThatObjectParcelable
+import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
 class StepTest {
     @Test
     fun stepIsParcelable() {
         val step = Step(id = 0, status = Step.Status.READY)
+        step.assertThatObjectParcelable<Step>()
+    }
+
+    @Test
+    fun stepWithDateIsParcelable() {
+        val step = Step(id = 0, status = Step.Status.READY, createDate = Date())
         step.assertThatObjectParcelable<Step>()
     }
 }


### PR DESCRIPTION
* fix date deserialization due to the wrong length of date pattern
* remove `Serializable` implementation from `Step`, `Block`, `Lesson` classes
* fix work with date in `Parcelable`
