### PR TITLE
feature/Amplitude analytics NPE

### DIFF
--- a/app/src/main/java/org/stepic/droid/analytic/AnalyticImpl.kt
+++ b/app/src/main/java/org/stepic/droid/analytic/AnalyticImpl.kt
@@ -83,7 +83,7 @@ constructor(
     override fun reportEvent(eventName: String, bundle: Bundle?) {
         val map: HashMap<String, String> = HashMap()
         bundle?.keySet()?.forEach {
-            map[it] = bundle[it].toString()
+            map[it] = java.lang.String.valueOf(bundle[it]) // handle null as bundle[it].toString() calls object.toString() and cause NPE instead of Any?.toString()
         }
         if (map.isEmpty()) {
             YandexMetrica.reportEvent(eventName)


### PR DESCRIPTION
**YouTrack task**: [#APPS-2196](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2196)

**Description List**:
* fix NPE on sending null params to Amplitude

**Description**:
`Bundle::get` has type `Any?` and Kotlin compiler supposedly should call safe extension method `Any?::toString`, but instead it calls `Object::toString` that causes `NullPointerException`