### PR TITLE
Feature/fix buy in web action

### DIFF
--- a/app/src/main/java/org/stepic/droid/core/ScreenManagerImpl.java
+++ b/app/src/main/java/org/stepic/droid/core/ScreenManagerImpl.java
@@ -4,7 +4,6 @@ package org.stepic.droid.core;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
@@ -15,7 +14,6 @@ import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.widget.Toast;
 
 import org.jetbrains.annotations.NotNull;

--- a/app/src/main/java/org/stepic/droid/core/ScreenManagerImpl.java
+++ b/app/src/main/java/org/stepic/droid/core/ScreenManagerImpl.java
@@ -4,6 +4,7 @@ package org.stepic.droid.core;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
@@ -14,6 +15,7 @@ import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.Toast;
 
 import org.jetbrains.annotations.NotNull;
@@ -650,9 +652,9 @@ public class ScreenManagerImpl implements ScreenManager {
 
         final Uri uri = uriBuilder.build();
 
-        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(config.getBaseUrl()));
 
-        final List<ResolveInfo> resolveInfoList = context.getPackageManager().queryIntentActivities(intent, 0);
+        final List<ResolveInfo> resolveInfoList = context.getPackageManager().queryIntentActivities(browserIntent, 0);
         final ArrayList<Intent> activityIntents = new ArrayList<>();
 
         for (final ResolveInfo resolveInfo : resolveInfoList) {


### PR DESCRIPTION
**YouTrack task**: [#APPS-2218](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2218)

**Description List**:
* fix buy in web action 

Due to [intent resolving](https://movieos.org/2015/working-around-android-m-intent-resolving/) only current package name is returned for deep link url. To avoid it you should pass non deep link url and retrieve intent list for it.
