### PR TITLE
mins instead of min

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -633,7 +633,7 @@
 
     <string name="course_content_unit_title" translatable="false">%d.%d %s</string>
     <string name="course_content_time_to_complete" translatable="false">&#8776; %s</string>
-    <string name="course_content_time_to_complete_minutes_unit">%d min</string>
+    <string name="course_content_time_to_complete_minutes_unit">%d mins</string>
     <string name="course_content_time_to_complete_hours_unit">%d h</string>
     <string name="course_content_text_progress" translatable="false">%d/%d</string>
 


### PR DESCRIPTION
Write "X mins" instead of "X min" in the syllabus. Will work better for everything except for `X == 1`.
