### PR TITLE
Feature/appcompat 1.1.0 webview crash fix

### DIFF
--- a/app/src/main/java/org/stepic/droid/ui/custom/LatexSupportableWebView.java
+++ b/app/src/main/java/org/stepic/droid/ui/custom/LatexSupportableWebView.java
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat;
 import org.stepic.droid.R;
 import org.stepic.droid.base.App;
 import org.stepic.droid.configuration.Config;
+import org.stepic.droid.util.ContextExtensionsKt;
 import org.stepic.droid.util.DpPixelsHelper;
 import org.stepic.droid.util.HtmlHelper;
 
@@ -52,7 +53,7 @@ public class LatexSupportableWebView extends WebView implements View.OnClickList
     }
 
     public LatexSupportableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
+        super(ContextExtensionsKt.contextForWebView(context), attrs, defStyleAttr);
 
         int[] set = {
                 android.R.attr.textColorHighlight

--- a/app/src/main/java/org/stepic/droid/util/ContextExtensions.kt
+++ b/app/src/main/java/org/stepic/droid/util/ContextExtensions.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
@@ -19,3 +20,13 @@ fun Context.copyTextToClipboard(label: String? = null, textToCopy: String, toast
     clipboardManager.primaryClip = ClipData.newPlainText(label, textToCopy)
     Toast.makeText(this, toastMessage, Toast.LENGTH_SHORT).show()
 }
+
+/**
+ * Workaround appcompat-1.1.0 bug https://issuetracker.google.com/issues/141132133
+ */
+fun Context.contextForWebView(): Context =
+    if (Build.VERSION.SDK_INT in 21..22) {
+        applicationContext
+    } else {
+        this
+    }


### PR DESCRIPTION
**YouTrack task**: [#APPS-2573](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2573)

**Description List**:
* Handle crash in custom web view for API 21 & 22

For more information relating to the crash:
* https://issuetracker.google.com/issues/141132133
* https://stackoverflow.com/questions/58028821/android-q-webview-crash-on-android-5-5-1-api-21-22-resourcesnotfoundexcepti