### PR TITLE
APPS-2987: snackbar crash fix

### DIFF
--- a/app/src/main/java/org/stepik/android/view/catalog/ui/adapter/delegate/CourseListAdapterDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/catalog/ui/adapter/delegate/CourseListAdapterDelegate.kt
@@ -134,6 +134,7 @@ class CourseListAdapterDelegate(
         }
 
         override fun showNetworkError() {
+            if (itemView.parent == null) return
             delegate.showNetworkError()
         }
 

--- a/app/src/main/java/org/stepik/android/view/catalog/ui/adapter/delegate/CourseListQueryAdapterDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/catalog/ui/adapter/delegate/CourseListQueryAdapterDelegate.kt
@@ -127,6 +127,7 @@ class CourseListQueryAdapterDelegate(
         }
 
         override fun showNetworkError() {
+            if (itemView.parent == null) return
             delegate.showNetworkError()
         }
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-2987](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2987)

**Description List**:
* Don't show snackbar message when viewholder parent is null

