### PR TITLE
Migrate kotlin-android-extensions to kotlin-parcelize

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'com.google.firebase.crashlytics'
 apply from: '../code_quality_tools/jacoco.gradle'
 //apply from: '../code_quality_tools/findbugs.gradle'
@@ -154,10 +154,6 @@ android {
         viewBinding true
     }
     namespace 'org.stepic.droid'
-}
-
-androidExtensions {
-    experimental = true
 }
 
 configurations {

--- a/app/src/main/java/org/stepic/droid/model/CertificateListItem.kt
+++ b/app/src/main/java/org/stepic/droid/model/CertificateListItem.kt
@@ -1,7 +1,7 @@
 package org.stepic.droid.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Certificate
 
 sealed class CertificateListItem : Parcelable {

--- a/app/src/main/java/org/stepic/droid/persistence/model/StepPersistentWrapper.kt
+++ b/app/src/main/java/org/stepic/droid/persistence/model/StepPersistentWrapper.kt
@@ -1,8 +1,8 @@
 package org.stepic.droid.persistence.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import org.stepic.droid.util.AppConstants
 import org.stepik.android.model.Progressable
 import org.stepik.android.model.Step

--- a/app/src/main/java/org/stepik/android/data/course_list/model/CourseListQueryData.kt
+++ b/app/src/main/java/org/stepik/android/data/course_list/model/CourseListQueryData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.data.course_list.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CourseListQueryData(

--- a/app/src/main/java/org/stepik/android/data/purchase_notification/model/PurchaseNotificationScheduled.kt
+++ b/app/src/main/java/org/stepik/android/data/purchase_notification/model/PurchaseNotificationScheduled.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.data.purchase_notification.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class PurchaseNotificationScheduled(

--- a/app/src/main/java/org/stepik/android/domain/achievement/model/AchievementItem.kt
+++ b/app/src/main/java/org/stepik/android/domain/achievement/model/AchievementItem.kt
@@ -1,8 +1,8 @@
 package org.stepik.android.domain.achievement.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.achievements.Achievement
 import org.stepik.android.model.achievements.AchievementProgress
 import ru.nobird.app.core.model.Identifiable

--- a/app/src/main/java/org/stepik/android/domain/calendar/model/CalendarItem.kt
+++ b/app/src/main/java/org/stepik/android/domain/calendar/model/CalendarItem.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.calendar.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CalendarItem(

--- a/app/src/main/java/org/stepik/android/domain/course/model/CourseHeaderData.kt
+++ b/app/src/main/java/org/stepik/android/domain/course/model/CourseHeaderData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.course_payments.model.CoursePurchaseInfo
 import org.stepik.android.domain.course_payments.model.DefaultPromoCode
 import org.stepik.android.domain.course_payments.model.DeeplinkPromoCode

--- a/app/src/main/java/org/stepik/android/domain/course/model/CourseStats.kt
+++ b/app/src/main/java/org/stepik/android/domain/course/model/CourseStats.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Progress
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/course/model/EnrollmentState.kt
+++ b/app/src/main/java/org/stepik/android/domain/course/model/EnrollmentState.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.mobile_tiers.model.LightSku
 import org.stepik.android.domain.user_courses.model.UserCourse
 

--- a/app/src/main/java/org/stepik/android/domain/course_info/model/CourseInfoData.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_info/model/CourseInfoData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_info.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.user.User
 import org.stepik.android.view.video_player.model.VideoPlayerMediaData
 

--- a/app/src/main/java/org/stepik/android/domain/course_list/model/CourseListQuery.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_list/model/CourseListQuery.kt
@@ -2,7 +2,7 @@ package org.stepik.android.domain.course_list.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.filter.model.CourseListFilterQuery
 import ru.nobird.app.core.model.mapOfNotNull
 import java.io.Serializable

--- a/app/src/main/java/org/stepik/android/domain/course_list/model/UserCourseQuery.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_list/model/UserCourseQuery.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_list.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UserCourseQuery(

--- a/app/src/main/java/org/stepik/android/domain/course_payments/model/CoursePurchaseInfo.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_payments/model/CoursePurchaseInfo.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_payments.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.course_purchase.model.CoursePurchaseObfuscatedParams
 
 sealed class CoursePurchaseInfo : Parcelable {

--- a/app/src/main/java/org/stepik/android/domain/course_payments/model/DeeplinkPromoCode.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_payments/model/DeeplinkPromoCode.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_payments.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DeeplinkPromoCode(

--- a/app/src/main/java/org/stepik/android/domain/course_payments/model/DefaultPromoCode.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_payments/model/DefaultPromoCode.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_payments.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/course_payments/model/PromoCodeSku.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_payments/model/PromoCodeSku.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_payments.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.mobile_tiers.model.LightSku
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/course_purchase/model/CoursePurchaseObfuscatedParams.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_purchase/model/CoursePurchaseObfuscatedParams.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.course_purchase.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CoursePurchaseObfuscatedParams(

--- a/app/src/main/java/org/stepik/android/domain/course_revenue/model/CourseBeneficiary.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_revenue/model/CourseBeneficiary.kt
@@ -2,7 +2,7 @@ package org.stepik.android.domain.course_revenue.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CourseBeneficiary(

--- a/app/src/main/java/org/stepik/android/domain/course_revenue/model/CourseBenefit.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_revenue/model/CourseBenefit.kt
@@ -2,8 +2,8 @@ package org.stepik.android.domain.course_revenue.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/filter/model/CourseListFilterQuery.kt
+++ b/app/src/main/java/org/stepik/android/domain/filter/model/CourseListFilterQuery.kt
@@ -2,7 +2,7 @@ package org.stepik.android.domain.filter.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.filter_search.Difficulty
 import org.stepik.android.domain.filter_search.Language
 import org.stepik.android.domain.filter_search.Type

--- a/app/src/main/java/org/stepik/android/domain/filter/model/SubmissionsFilterQuery.kt
+++ b/app/src/main/java/org/stepik/android/domain/filter/model/SubmissionsFilterQuery.kt
@@ -2,7 +2,7 @@ package org.stepik.android.domain.filter.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.mapOfNotNull
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/lesson/model/LessonData.kt
+++ b/app/src/main/java/org/stepik/android/domain/lesson/model/LessonData.kt
@@ -1,8 +1,8 @@
 package org.stepik.android.domain.lesson.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Course
 import org.stepik.android.model.Lesson
 import org.stepik.android.model.Section

--- a/app/src/main/java/org/stepik/android/domain/mobile_tiers/model/LightSku.kt
+++ b/app/src/main/java/org/stepik/android/domain/mobile_tiers/model/LightSku.kt
@@ -3,7 +3,7 @@ package org.stepik.android.domain.mobile_tiers.model
 import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Entity

--- a/app/src/main/java/org/stepik/android/domain/review_instruction/model/ReviewInstruction.kt
+++ b/app/src/main/java/org/stepik/android/domain/review_instruction/model/ReviewInstruction.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.ReviewStrategyType
 import ru.nobird.app.core.model.Identifiable
 

--- a/app/src/main/java/org/stepik/android/domain/review_instruction/model/ReviewInstructionData.kt
+++ b/app/src/main/java/org/stepik/android/domain/review_instruction/model/ReviewInstructionData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.review_instruction.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.rubric.model.Rubric
 import ru.nobird.app.core.model.Identifiable
 

--- a/app/src/main/java/org/stepik/android/domain/rubric/model/Rubric.kt
+++ b/app/src/main/java/org/stepik/android/domain/rubric/model/Rubric.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Entity
 @Parcelize

--- a/app/src/main/java/org/stepik/android/domain/step_quiz/model/StepQuizLessonData.kt
+++ b/app/src/main/java/org/stepik/android/domain/step_quiz/model/StepQuizLessonData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.domain.step_quiz.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.lesson.model.LessonData
 import org.stepik.android.model.DiscountingPolicyType
 

--- a/app/src/main/java/org/stepik/android/domain/user_courses/model/UserCourse.kt
+++ b/app/src/main/java/org/stepik/android/domain/user_courses/model/UserCourse.kt
@@ -2,7 +2,7 @@ package org.stepik.android.domain.user_courses.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 @Parcelize

--- a/app/src/main/java/org/stepik/android/presentation/course_purchase/model/CoursePurchaseData.kt
+++ b/app/src/main/java/org/stepik/android/presentation/course_purchase/model/CoursePurchaseData.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.presentation.course_purchase.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.course.model.CourseStats
 import org.stepik.android.domain.course_payments.model.PromoCodeSku
 import org.stepik.android.domain.mobile_tiers.model.LightSku

--- a/app/src/main/java/org/stepik/android/remote/course_payments/model/PromoCodeResponse.kt
+++ b/app/src/main/java/org/stepik/android/remote/course_payments/model/PromoCodeResponse.kt
@@ -2,7 +2,7 @@ package org.stepik.android.remote.course_payments.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class PromoCodeResponse(

--- a/app/src/main/java/org/stepik/android/view/course_content/model/RequiredSection.kt
+++ b/app/src/main/java/org/stepik/android/view/course_content/model/RequiredSection.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.view.course_content.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Progress
 import org.stepik.android.model.Section
 

--- a/app/src/main/java/org/stepik/android/view/onboarding/model/OnboardingCourseList.kt
+++ b/app/src/main/java/org/stepik/android/view/onboarding/model/OnboardingCourseList.kt
@@ -2,7 +2,7 @@ package org.stepik.android.view.onboarding.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class OnboardingCourseList(

--- a/app/src/main/java/org/stepik/android/view/onboarding/model/OnboardingGoal.kt
+++ b/app/src/main/java/org/stepik/android/view/onboarding/model/OnboardingGoal.kt
@@ -2,7 +2,7 @@ package org.stepik.android.view.onboarding.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class OnboardingGoal(

--- a/app/src/main/java/org/stepik/android/view/step/model/SectionUnavailableAction.kt
+++ b/app/src/main/java/org/stepik/android/view/step/model/SectionUnavailableAction.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.view.step.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Lesson
 import org.stepik.android.model.Section
 import org.stepik.android.view.course_content.model.RequiredSection

--- a/app/src/main/java/org/stepik/android/view/step/model/StepNavigationAction.kt
+++ b/app/src/main/java/org/stepik/android/view/step/model/StepNavigationAction.kt
@@ -1,7 +1,7 @@
 package org.stepik.android.view.step.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.domain.lesson.model.LessonData
 import org.stepik.android.domain.step.model.StepNavigationDirection
 import org.stepik.android.model.Course

--- a/billing/build.gradle
+++ b/billing/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply from: '../code_quality_tools/jacoco.gradle'
 
 android {

--- a/model/src/main/java/org/stepik/android/model/Actions.kt
+++ b/model/src/main/java/org/stepik/android/model/Actions.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Actions(

--- a/model/src/main/java/org/stepik/android/model/Cell.kt
+++ b/model/src/main/java/org/stepik/android/model/Cell.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/Certificate.kt
+++ b/model/src/main/java/org/stepik/android/model/Certificate.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/Course.kt
+++ b/model/src/main/java/org/stepik/android/model/Course.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 import java.util.Date
 

--- a/model/src/main/java/org/stepik/android/model/CourseActions.kt
+++ b/model/src/main/java/org/stepik/android/model/CourseActions.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CourseActions(

--- a/model/src/main/java/org/stepik/android/model/CourseBuyAction.kt
+++ b/model/src/main/java/org/stepik/android/model/CourseBuyAction.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CourseBuyAction(

--- a/model/src/main/java/org/stepik/android/model/CourseCollection.kt
+++ b/model/src/main/java/org/stepik/android/model/CourseCollection.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/Lesson.kt
+++ b/model/src/main/java/org/stepik/android/model/Lesson.kt
@@ -2,8 +2,8 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 import java.util.Date
 

--- a/model/src/main/java/org/stepik/android/model/Progress.kt
+++ b/model/src/main/java/org/stepik/android/model/Progress.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/Reply.kt
+++ b/model/src/main/java/org/stepik/android/model/Reply.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Reply(

--- a/model/src/main/java/org/stepik/android/model/Section.kt
+++ b/model/src/main/java/org/stepik/android/model/Section.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 import java.util.Date
 

--- a/model/src/main/java/org/stepik/android/model/Step.kt
+++ b/model/src/main/java/org/stepik/android/model/Step.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/StoryTemplate.kt
+++ b/model/src/main/java/org/stepik/android/model/StoryTemplate.kt
@@ -3,7 +3,7 @@ package org.stepik.android.model
 import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class StoryTemplate(
         @SerializedName("id")

--- a/model/src/main/java/org/stepik/android/model/TableChoiceAnswer.kt
+++ b/model/src/main/java/org/stepik/android/model/TableChoiceAnswer.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class TableChoiceAnswer(

--- a/model/src/main/java/org/stepik/android/model/Unit.kt
+++ b/model/src/main/java/org/stepik/android/model/Unit.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 import java.util.Date
 

--- a/model/src/main/java/org/stepik/android/model/ViewRevenue.kt
+++ b/model/src/main/java/org/stepik/android/model/ViewRevenue.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class ViewRevenue(

--- a/model/src/main/java/org/stepik/android/model/attempts/Dataset.kt
+++ b/model/src/main/java/org/stepik/android/model/attempts/Dataset.kt
@@ -3,7 +3,7 @@ package org.stepik.android.model.attempts
 import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Dataset(

--- a/model/src/main/java/org/stepik/android/model/code/CodeOptions.kt
+++ b/model/src/main/java/org/stepik/android/model/code/CodeOptions.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model.code
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.util.ParcelableStringList
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/code/UserCodeRun.kt
+++ b/model/src/main/java/org/stepik/android/model/code/UserCodeRun.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model.code
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.*
 
 @Parcelize

--- a/model/src/main/java/org/stepik/android/model/comments/Comment.kt
+++ b/model/src/main/java/org/stepik/android/model/comments/Comment.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model.comments
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.stepik.android.model.Actions
 import org.stepik.android.model.UserRole
 import java.util.*

--- a/model/src/main/java/org/stepik/android/model/user/Profile.kt
+++ b/model/src/main/java/org/stepik/android/model/user/Profile.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model.user
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Profile(

--- a/model/src/main/java/org/stepik/android/model/user/User.kt
+++ b/model/src/main/java/org/stepik/android/model/user/User.kt
@@ -2,7 +2,7 @@ package org.stepik.android.model.user
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import ru.nobird.app.core.model.Identifiable
 import java.util.Date
 


### PR DESCRIPTION
Migrates the project from `kotlin-android-extensions` to `kotlin-parcelize`.

What changed:
- Replaced the legacy Android Extensions plugin with `kotlin-parcelize` in `app` and `model`.
- Removed the obsolete Android Extensions plugin from `billing`, which no longer needs it.
- Updated all `kotlinx.android.parcel.*` imports to `kotlinx.parcelize.*`.
- Removed the `androidExtensions { experimental = true }` block from `app`.

Verification:
- `./gradlew :app:assembleDebug --rerun-tasks -Pkotlin.compiler.execution.strategy=in-process`
- `./gradlew :app:assembleRelease --rerun-tasks -Pkotlin.compiler.execution.strategy=in-process`
- manual smoke tested debug and release app

The build completes successfully; remaining warnings are pre-existing deprecations/resource-format issues.