### PR TITLE
Bump Kotlin to 2.1.21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,6 +168,7 @@ dependencies {
     implementation files('libs/flexbox-release.aar')
     implementation project(':billing')
     implementation project(':model')
+    implementation platform(libraries.kotlinBom)
     implementation libraries.kotlinStd
 
     //<DI>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,12 @@ android {
         jvmTarget = "1.8"
     }
 
+    kapt {
+        arguments {
+            arg("dagger.useBindingGraphFix", "ENABLED")
+        }
+    }
+
     buildFeatures {
         viewBinding true
     }

--- a/app/src/debug/java/org/stepik/android/view/injection/debug/DebugPresentationModule.kt
+++ b/app/src/debug/java/org/stepik/android/view/injection/debug/DebugPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.DebugFeature
 import org.stepik.android.presentation.debug.DebugViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object DebugPresentationModule {
     /**
      * Presentation

--- a/app/src/debug/java/org/stepik/android/view/injection/debug/InAppPurchasesPresentationModule.kt
+++ b/app/src/debug/java/org/stepik/android/view/injection/debug/InAppPurchasesPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.InAppPurchasesFeature
 import org.stepik.android.presentation.debug.InAppPurchasesViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object InAppPurchasesPresentationModule {
     /**
      * Presentation

--- a/app/src/debug/java/org/stepik/android/view/injection/debug/SplitTestsPresentationModule.kt
+++ b/app/src/debug/java/org/stepik/android/view/injection/debug/SplitTestsPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.SplitTestsFeature
 import org.stepik.android.presentation.debug.SplitTestsViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object SplitTestsPresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepic/droid/adaptive/util/RatingNamesGenerator.kt
+++ b/app/src/main/java/org/stepic/droid/adaptive/util/RatingNamesGenerator.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import org.stepic.droid.R
 import org.stepic.droid.di.AppSingleton
 import org.stepic.droid.preferences.SharedPreferenceHelper
+import java.util.Locale
 import javax.inject.Inject
 
 @AppSingleton
@@ -34,7 +35,7 @@ constructor(
                 adjectives[adjIndex]
             }
 
-            adj.capitalize() + ' ' + animal
+            adj.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } + ' ' + animal
         }
 
     private fun isFemaleNoun(noun: String) = animalsFemale.contains(noun)

--- a/app/src/main/java/org/stepic/droid/analytic/AnalyticImpl.kt
+++ b/app/src/main/java/org/stepic/droid/analytic/AnalyticImpl.kt
@@ -281,7 +281,7 @@ constructor(
 
     private fun castStringToFirebaseEvent(eventName: String): String {
         val firebaseEventName = eventName
-            .decapitalize(Locale.ENGLISH)
+            .replaceFirstChar { it.lowercase(Locale.ENGLISH) }
             .replace(' ', '_')
 
         return firebaseEventName.take(FIREBASE_LENGTH_LIMIT)

--- a/app/src/main/java/org/stepic/droid/core/presenters/SearchSuggestionsPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/SearchSuggestionsPresenter.kt
@@ -13,6 +13,7 @@ import org.stepic.droid.di.qualifiers.MainScheduler
 import org.stepic.droid.model.SearchQuerySource
 import org.stepik.android.domain.base.DataSourceType
 import org.stepik.android.domain.search.repository.SearchRepository
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class SearchSuggestionsPresenter
@@ -59,7 +60,7 @@ constructor(
     }
 
     fun onQueryTextSubmit(query: String) {
-        analytic.reportAmplitudeEvent(AmplitudeAnalytic.Search.SEARCHED, mapOf(AmplitudeAnalytic.Search.PARAM_SUGGESTION to query.toLowerCase()))
+        analytic.reportAmplitudeEvent(AmplitudeAnalytic.Search.SEARCHED, mapOf(AmplitudeAnalytic.Search.PARAM_SUGGESTION to query.lowercase(Locale.getDefault())))
     }
 
     override fun detachView(view: SearchSuggestionsView) {

--- a/app/src/main/java/org/stepic/droid/di/AppCoreModule.kt
+++ b/app/src/main/java/org/stepic/droid/di/AppCoreModule.kt
@@ -5,7 +5,6 @@ import android.app.NotificationManager
 import android.content.ContentResolver
 import android.content.Context
 import android.net.ConnectivityManager
-import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfig
@@ -51,7 +50,6 @@ import org.stepic.droid.util.resolvers.StepTypeResolver
 import org.stepic.droid.util.resolvers.StepTypeResolverImpl
 import org.stepic.droid.util.resolvers.text.TextResolver
 import org.stepic.droid.util.resolvers.text.TextResolverImpl
-import org.stepik.android.presentation.base.injection.DaggerViewModelFactory
 import org.stepik.android.view.injection.billing.PublicLicenseKey
 import org.stepik.android.view.injection.qualifiers.AuthLock
 import retrofit2.Retrofit
@@ -97,9 +95,6 @@ abstract class AppCoreModule {
     @Binds
     @AppSingleton
     abstract fun bindStepTypeResolver(stepTypeResolver: StepTypeResolverImpl): StepTypeResolver
-
-    @Binds
-    internal abstract fun bindViewModelFactory(daggerViewModelFactory: DaggerViewModelFactory): ViewModelProvider.Factory
 
     @Module
     companion object {

--- a/app/src/main/java/org/stepic/droid/storage/dao/SearchQueryDaoImpl.kt
+++ b/app/src/main/java/org/stepic/droid/storage/dao/SearchQueryDaoImpl.kt
@@ -6,6 +6,7 @@ import org.stepic.droid.model.SearchQuery
 import org.stepic.droid.model.SearchQuerySource
 import org.stepic.droid.storage.operations.DatabaseOperations
 import org.stepic.droid.storage.structure.DbStructureSearchQuery
+import java.util.Locale
 import javax.inject.Inject
 
 
@@ -18,16 +19,16 @@ constructor(databaseOperations: DatabaseOperations) : DaoBase<SearchQuery>(datab
 
     override fun getDefaultPrimaryColumn(): String = DbStructureSearchQuery.Column.QUERY_HASH
 
-    override fun getDefaultPrimaryValue(persistentObject: SearchQuery): String = persistentObject.text.toLowerCase().hashCode().toString()
+    override fun getDefaultPrimaryValue(persistentObject: SearchQuery): String = persistentObject.text.lowercase(Locale.getDefault()).hashCode().toString()
 
     override fun getContentValues(persistentObject: SearchQuery): ContentValues {
         val contentValues = ContentValues()
 
         contentValues.put(DbStructureSearchQuery.Column.QUERY_COURSE_ID, persistentObject.courseId)
         val queryHash = if (persistentObject.courseId != -1L) {
-            "${COURSE_PREFIX}_${persistentObject.courseId}_${persistentObject.text}".toLowerCase().hashCode()
+            "${COURSE_PREFIX}_${persistentObject.courseId}_${persistentObject.text}".lowercase(Locale.getDefault()).hashCode()
         } else {
-            persistentObject.text.toLowerCase().hashCode()
+            persistentObject.text.lowercase(Locale.getDefault()).hashCode()
         }
         contentValues.put(DbStructureSearchQuery.Column.QUERY_HASH, queryHash)  // toLowerCase to avoid problems with case sensitive duplicates due to SQLite
         contentValues.put(DbStructureSearchQuery.Column.QUERY_TEXT, persistentObject.text)
@@ -48,7 +49,7 @@ constructor(databaseOperations: DatabaseOperations) : DaoBase<SearchQuery>(datab
                         "ORDER BY ${DbStructureSearchQuery.Column.QUERY_TIMESTAMP} DESC " +
                         "LIMIT $count"
 
-        val pattern = "%${constraint.toLowerCase()}%"
+        val pattern = "%${constraint.lowercase(Locale.getDefault())}%"
         return getAllWithQuery(sql, arrayOf(pattern, courseId.toString()))
     }
 

--- a/app/src/main/java/org/stepic/droid/ui/adapters/NotificationAdapter.java
+++ b/app/src/main/java/org/stepic/droid/ui/adapters/NotificationAdapter.java
@@ -27,11 +27,11 @@ import org.stepik.android.view.base.ui.extension.ColorExtensions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import javax.inject.Inject;
 
-import kotlin.text.StringsKt;
 import timber.log.Timber;
 
 public class NotificationAdapter extends RecyclerView.Adapter<NotificationAdapter.GenericViewHolder> implements StickyHeaderAdapter<NotificationAdapter.DateHeaderViewHolder> {
@@ -183,12 +183,25 @@ public class NotificationAdapter extends RecyclerView.Adapter<NotificationAdapte
 
             String date = DateTimeHelper.INSTANCE.getPrintableOfIsoDate(notification.getTime(), AppConstants.NOTIFICATIONS_GROUP_DATE, TimeZone.getDefault());
             String day = DateTimeHelper.INSTANCE.getPrintableOfIsoDate(notification.getTime(), AppConstants.NOTIFICATIONS_GROUP_DAY, TimeZone.getDefault());
-            viewHolder.sectionDate.setText(StringsKt.capitalize(date));
-            viewHolder.sectionDay.setText(StringsKt.capitalize(day));
+            viewHolder.sectionDate.setText(capitalize(date));
+            viewHolder.sectionDay.setText(capitalize(day));
             ViewKt.setVisible(viewHolder.itemView, true);
         }
     }
 
+    private static String capitalize(String value) {
+        if (!value.isEmpty()) {
+            char firstChar = value.charAt(0);
+            if (Character.isLowerCase(firstChar)) {
+                char titleChar = Character.toTitleCase(firstChar);
+                String first = titleChar != Character.toUpperCase(firstChar)
+                        ? String.valueOf(titleChar)
+                        : value.substring(0, 1).toUpperCase(Locale.getDefault());
+                return first + value.substring(1);
+            }
+        }
+        return value;
+    }
 
     public static final class DateHeaderViewHolder extends RecyclerView.ViewHolder {
         private final TextView sectionDate;

--- a/app/src/main/java/org/stepic/droid/ui/adapters/SearchQueriesAdapter.kt
+++ b/app/src/main/java/org/stepic/droid/ui/adapters/SearchQueriesAdapter.kt
@@ -20,6 +20,7 @@ import org.stepic.droid.ui.custom.AutoCompleteSearchView
 import org.stepic.droid.ui.listeners.OnItemClickListener
 import org.stepic.droid.util.resolveColorAttribute
 import ru.nobird.android.view.base.ui.extension.inflate
+import java.util.Locale
 import javax.inject.Inject
 
 class SearchQueriesAdapter(context: Context) : RecyclerView.Adapter<SearchQueriesAdapter.SearchQueryViewHolder>(), OnItemClickListener {
@@ -80,7 +81,7 @@ class SearchQueriesAdapter(context: Context) : RecyclerView.Adapter<SearchQuerie
     private fun filterItems() {
         items = (rawDBItems + rawAPIItems)
                 .filter { it.text.contains(constraint, ignoreCase = true) }
-                .distinctBy { it.text.toLowerCase() }
+                .distinctBy { it.text.lowercase(Locale.getDefault()) }
                 .map {
                     val spannable = SpannableString(it.text)
                     val spanStart = it.text.indexOf(constraint, ignoreCase = true)

--- a/app/src/main/java/org/stepik/android/domain/course_revenue/analytic/CourseBenefitClickedEvent.kt
+++ b/app/src/main/java/org/stepik/android/domain/course_revenue/analytic/CourseBenefitClickedEvent.kt
@@ -23,7 +23,7 @@ class CourseBenefitClickedEvent(
     override val params: Map<String, Any> =
         mapOf(
             PARAM_BENEFIT to benefitId,
-            PARAM_STATUS to benefitStatus.name.toLowerCase(Locale.ROOT),
+            PARAM_STATUS to benefitStatus.name.lowercase(Locale.ROOT),
             PARAM_COURSE to courseId,
             PARAM_COURSE_TITLE to courseTitle.orEmpty()
         )

--- a/app/src/main/java/org/stepik/android/domain/lesson/interactor/LessonContentInteractor.kt
+++ b/app/src/main/java/org/stepik/android/domain/lesson/interactor/LessonContentInteractor.kt
@@ -60,7 +60,7 @@ constructor(
 
     private fun getAssignments(unit: Unit?): Single<List<Assignment>> =
         assignmentRepository
-            .getAssignments(*unit?.assignments ?: emptyList())
+            .getAssignments(unit?.assignments ?: emptyList())
 
     private fun packStepItems(assignments: List<Assignment>, steps: List<StepPersistentWrapper>, progresses: List<Progress>, reviewSessions: List<ReviewSessionData>): List<StepItem> =
         steps

--- a/app/src/main/java/org/stepik/android/view/course_revenue/ui/adapter/delegate/CourseBenefitsMonthlyAdapterDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/course_revenue/ui/adapter/delegate/CourseBenefitsMonthlyAdapterDelegate.kt
@@ -43,7 +43,7 @@ class CourseBenefitsMonthlyAdapterDelegate(
                 data.courseBenefitByMonth.date,
                 DateTimeHelper.DISPLAY_MONTH_YEAR_NOMINAL_PATTERN,
                 TimeZone.getDefault()
-            ).capitalize(Locale.ROOT)
+            ).replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
 
             val (incomeString, incomeStringColor) = resolveIncomeString(data.courseBenefitByMonth.totalUserIncome, data.courseBenefitByMonth.currencyCode, decimalFormat)
             viewBinding.courseBenefitByMonthIncome.text = incomeString

--- a/app/src/main/java/org/stepik/android/view/course_revenue/ui/delegate/CourseBenefitSummaryViewDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/course_revenue/ui/delegate/CourseBenefitSummaryViewDelegate.kt
@@ -67,13 +67,13 @@ class CourseBenefitSummaryViewDelegate(
                 state.courseBenefitSummary.currentDate,
                 DateTimeHelper.DISPLAY_MONTH_YEAR_NOMINAL_PATTERN,
                 TimeZone.getDefault()
-            ).capitalize(Locale.ROOT)
+            ).replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
 
             val totalDate = DateTimeHelper.getPrintableDate(
                 state.courseBenefitSummary.beginPaymentDate,
                 DateTimeHelper.DISPLAY_MONTH_YEAR_GENITIVE_PATTERN,
                 TimeZone.getDefault()
-            ).capitalize(Locale.ROOT)
+            ).replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
 
             binding.courseBenefitSummaryEarningsCurrentMonthText.text = context.getString(R.string.course_benefits_earning_current_month, currentMonthDate)
             binding.courseBenefitSummaryEarningsCurrentMonthValue.text = revenuePriceMapper.mapToDisplayPrice(state.courseBenefitSummary.currencyCode, decimalFormat.format(state.courseBenefitSummary.monthUserIncome.toDoubleOrNull() ?: 0.0))

--- a/app/src/main/java/org/stepik/android/view/font_size_settings/ui/dialog/ChooseFontSizeDialogFragment.kt
+++ b/app/src/main/java/org/stepik/android/view/font_size_settings/ui/dialog/ChooseFontSizeDialogFragment.kt
@@ -53,7 +53,7 @@ class ChooseFontSizeDialogFragment : DialogFragment(), FontSizeView {
                 val fontSize = FontSize.values()[which]
                 presenter.onFontSizeChosen(fontSize)
                 analytic.reportAmplitudeEvent(AmplitudeAnalytic.FontSize.FONT_SIZE_SELECTED, mapOf(
-                    AmplitudeAnalytic.FontSize.Params.SIZE to fontSize.name.toLowerCase(Locale.ROOT)
+                    AmplitudeAnalytic.FontSize.Params.SIZE to fontSize.name.lowercase(Locale.ROOT)
                 ))
                 dismiss()
             }

--- a/app/src/main/java/org/stepik/android/view/injection/achievements/AchievementsModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/achievements/AchievementsModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.achievement.AchievementsPresenter
 import org.stepik.android.presentation.base.injection.ViewModelKey
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class AchievementsModule {
 
     /**

--- a/app/src/main/java/org/stepik/android/view/injection/auth/AuthModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/auth/AuthModule.kt
@@ -4,12 +4,13 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.auth.CredentialAuthPresenter
 import org.stepik.android.presentation.auth.RegistrationPresenter
 import org.stepik.android.presentation.auth.SocialAuthPresenter
 import org.stepik.android.presentation.base.injection.ViewModelKey
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class AuthModule {
 
     /**

--- a/app/src/main/java/org/stepik/android/view/injection/base/ViewModelFactoryModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/base/ViewModelFactoryModule.kt
@@ -1,0 +1,17 @@
+package org.stepik.android.view.injection.base
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.Multibinds
+import org.stepik.android.presentation.base.injection.DaggerViewModelFactory
+
+@Module
+abstract class ViewModelFactoryModule {
+    @Binds
+    internal abstract fun bindViewModelFactory(daggerViewModelFactory: DaggerViewModelFactory): ViewModelProvider.Factory
+
+    @Multibinds
+    internal abstract fun bindViewModels(): Map<Class<out ViewModel>, @JvmSuppressWildcards ViewModel>
+}

--- a/app/src/main/java/org/stepik/android/view/injection/catalog/CatalogBlockPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/catalog/CatalogBlockPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.banner.BannerFeature
 import org.stepik.android.presentation.banner.dispatcher.BannerActionDispatcher
 import org.stepik.android.presentation.base.injection.ViewModelKey
@@ -30,7 +31,7 @@ import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CatalogBlockPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/certificate/CertificateModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/certificate/CertificateModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.certificate.CertificatesPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CertificateModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/comment/CommentsModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/comment/CommentsModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.comment.CommentsPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class CommentsModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/comment/ComposeCommentModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/comment/ComposeCommentModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.comment.ComposeCommentPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class ComposeCommentModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/course/CourseModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course/CourseModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.subjects.BehaviorSubject
@@ -15,7 +16,7 @@ import org.stepik.android.presentation.course_content.CourseContentPresenter
 import org.stepik.android.presentation.course_info.CourseInfoPresenter
 import org.stepik.android.presentation.course_reviews.CourseReviewsPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/course/CourseNewsPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course/CourseNewsPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_news.CourseNewsFeature
 import org.stepik.android.presentation.course_news.CourseNewsViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CourseNewsPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course/CoursePresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course/CoursePresentationModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course.CoursePresenter
 import org.stepik.android.presentation.course.CourseView
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CoursePresentationModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_complete/CourseCompletePresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_complete/CourseCompletePresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_complete.CourseCompleteFeature
 import org.stepik.android.presentation.course_complete.CourseCompleteViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CourseCompletePresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/collection/CourseListCollectionModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/collection/CourseListCollectionModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListCollectionPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListCollectionModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/query/CourseListQueryModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/query/CourseListQueryModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListQueryPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListQueryModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/search_result/CourseListSearchResultModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/search_result/CourseListSearchResultModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListSearchPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListSearchResultModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/user/CourseListUserModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/user/CourseListUserModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListUserPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListUserModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/visited/CourseListVisitedModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/visited/CourseListVisitedModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListView
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListVisitedModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_list/wishlist/CourseListWishModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_list/wishlist/CourseListWishModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.course_list.CourseListWishPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class CourseListWishModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_purchase/CoursePurchasePresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_purchase/CoursePurchasePresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_purchase.CoursePurchaseFeature
 import org.stepik.android.presentation.course_purchase.CoursePurchaseViewModel
@@ -16,7 +17,7 @@ import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CoursePurchasePresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/course_revenue/CourseRevenuePresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_revenue/CourseRevenuePresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_revenue.CourseBenefitSummaryFeature
 import org.stepik.android.presentation.course_revenue.CourseRevenueFeature
@@ -21,7 +22,7 @@ import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CourseRevenuePresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/course_reviews/ComposeCourseReviewModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_reviews/ComposeCourseReviewModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_reviews.ComposeCourseReviewPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class ComposeCourseReviewModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/course_search/CourseSearchPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/course_search/CourseSearchPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_search.CourseSearchFeature
 import org.stepik.android.presentation.course_search.CourseSearchViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object CourseSearchPresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/download/DownloadModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/download/DownloadModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.download.DownloadPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class DownloadModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/fast_continue/FastContinueModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/fast_continue/FastContinueModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.fast_continue.FastContinuePresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class FastContinueModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/feedback/FeedbackModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/feedback/FeedbackModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.feedback.FeedbackPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class FeedbackModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/filter/FilterModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/filter/FilterModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.filter.FiltersPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class FilterModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/filter_search/FilterSearchModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/filter_search/FilterSearchModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.filter_search.FilterSearchPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class FilterSearchModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/font_size_settings/FontSizeModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/font_size_settings/FontSizeModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.font_size_settings.FontSizePresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class FontSizeModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/in_app_web_view/InAppWebViewModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/in_app_web_view/InAppWebViewModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.in_app_web_view.InAppWebViewPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class InAppWebViewModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/lesson/LessonModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/lesson/LessonModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.lesson.LessonPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class LessonModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/lesson_demo/LessonDemoPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/lesson_demo/LessonDemoPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.model.Course
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.lesson_demo.LessonDemoFeature
@@ -18,7 +19,7 @@ import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object LessonDemoPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/magic_links/MagicLinksModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/magic_links/MagicLinksModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.magic_links.MagicLinkPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class MagicLinksModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/profile/ProfileCoursesPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/profile/ProfileCoursesPresentationModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.course_continue.CourseContinueView
 import org.stepik.android.presentation.profile_courses.ProfileCoursesPresenter
@@ -13,7 +14,7 @@ import ru.nobird.android.presentation.base.DefaultPresenterViewContainer
 import ru.nobird.android.presentation.base.PresenterViewContainer
 import ru.nobird.android.presentation.base.ViewContainer
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class ProfileCoursesPresentationModule {
 
     @Binds

--- a/app/src/main/java/org/stepik/android/view/injection/profile/ProfileModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/profile/ProfileModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.subjects.BehaviorSubject
@@ -20,7 +21,7 @@ import org.stepik.android.presentation.profile_id.ProfileIdPresenter
 import org.stepik.android.presentation.profile_links.ProfileLinksPresenter
 import org.stepik.android.presentation.profile_notification.ProfileNotificationPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class ProfileModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/profile_edit/ProfileEditModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/profile_edit/ProfileEditModule.kt
@@ -4,12 +4,13 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.profile_edit.ProfileEditInfoPresenter
 import org.stepik.android.presentation.profile_edit.ProfileEditPasswordPresenter
 import org.stepik.android.presentation.profile_edit.ProfileEditPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class ProfileEditModule {
 
     /**

--- a/app/src/main/java/org/stepik/android/view/injection/rubricator/RubricatorPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/rubricator/RubricatorPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.rubricator.RubricatorActionDispatcher
 import org.stepik.android.presentation.rubricator.RubricatorFeature
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object RubricatorPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/settings/SettingsModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/settings/SettingsModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.settings.SettingsPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class SettingsModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/solutions/SolutionsModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/solutions/SolutionsModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.solutions.SolutionsPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class SolutionsModule {
     /**
      * PRESENTATION LAYER

--- a/app/src/main/java/org/stepik/android/view/injection/step/StepModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/step/StepModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.step.StepPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class StepModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/step_content_text/TextStepContentModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/step_content_text/TextStepContentModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.step_content_text.TextStepContentPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class TextStepContentModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/step_content_video/VideoStepContentModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/step_content_video/VideoStepContentModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.step_content_video.VideoStepContentPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class VideoStepContentModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/step_quiz/StepQuizPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/step_quiz/StepQuizPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.step_quiz.StepQuizFeature
 import org.stepik.android.presentation.step_quiz.StepQuizViewModel
@@ -23,7 +24,7 @@ import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object StepQuizPresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/step_source/StepSourceModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/step_source/StepSourceModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.step_source.EditStepSourcePresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class StepSourceModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/stories/StoriesPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/stories/StoriesPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.stories.StoriesFeature
 import org.stepik.android.presentation.stories.dispatcher.StoriesActionDispatcher
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal object StoriesPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/story/StoryPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/story/StoryPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.story.StoryActionDispatcher
 import org.stepik.android.presentation.story.StoryFeature
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal object StoryPresentationModule {
     @Provides
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/story_deeplink/StoryDeepLinkPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/story_deeplink/StoryDeepLinkPresentationModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.story_deeplink.StoryDeepLinkPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class StoryDeepLinkPresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/submission/SubmissionModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/submission/SubmissionModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.submission.SubmissionsPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 internal abstract class SubmissionModule {
 
     /**

--- a/app/src/main/java/org/stepik/android/view/injection/user_code_run/UserCodeRunModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/user_code_run/UserCodeRunModule.kt
@@ -5,6 +5,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.data.user_code_run.repository.UserCodeRunRepositoryImpl
 import org.stepik.android.data.user_code_run.source.UserCodeRunRemoteDataSource
 import org.stepik.android.domain.user_code_run.repository.UserCodeRunRepository
@@ -15,7 +16,7 @@ import org.stepik.android.remote.user_code_run.service.UserCodeRunService
 import org.stepik.android.view.injection.base.Authorized
 import retrofit2.Retrofit
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class UserCodeRunModule {
 
     @Binds

--- a/app/src/main/java/org/stepik/android/view/injection/user_reviews/UserReviewsPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/user_reviews/UserReviewsPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.redux.wrapWithRefCounter
 import org.stepik.android.presentation.user_reviews.UserReviewsFeature
@@ -15,7 +16,7 @@ import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.Feature
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object UserReviewsPresentationModule {
     /**
      * Presentation

--- a/app/src/main/java/org/stepik/android/view/injection/video_player/VideoPlayerModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/video_player/VideoPlayerModule.kt
@@ -4,10 +4,11 @@ import androidx.lifecycle.ViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.video_player.VideoPlayerPresenter
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 abstract class VideoPlayerModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/org/stepik/android/view/injection/wishlist/WishlistPresentationModule.kt
+++ b/app/src/main/java/org/stepik/android/view/injection/wishlist/WishlistPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.wishlist.WishlistFeature
 import org.stepik.android.presentation.wishlist.WishlistViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object WishlistPresentationModule {
     /**
      * Presentation

--- a/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/DebugPresentationModule.kt
+++ b/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/DebugPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.DebugFeature
 import org.stepik.android.presentation.debug.DebugViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object DebugPresentationModule {
     /**
      * Presentation

--- a/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/InAppPurchasesPresentationModule.kt
+++ b/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/InAppPurchasesPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.InAppPurchasesFeature
 import org.stepik.android.presentation.debug.InAppPurchasesViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object InAppPurchasesPresentationModule {
     /**
      * Presentation

--- a/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/SplitTestsPresentationModule.kt
+++ b/app/src/stageDebuggable/java/org/stepik/android/view/injection/debug/SplitTestsPresentationModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import org.stepik.android.view.injection.base.ViewModelFactoryModule
 import org.stepik.android.presentation.base.injection.ViewModelKey
 import org.stepik.android.presentation.debug.SplitTestsFeature
 import org.stepik.android.presentation.debug.SplitTestsViewModel
@@ -13,7 +14,7 @@ import ru.nobird.app.presentation.redux.container.wrapWithViewContainer
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
 import ru.nobird.app.presentation.redux.feature.ReduxFeature
 
-@Module
+@Module(includes = [ViewModelFactoryModule::class])
 object SplitTestsPresentationModule {
     /**
      * Presentation

--- a/billing/build.gradle
+++ b/billing/build.gradle
@@ -20,12 +20,23 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     namespace 'org.stepik.android.billing'
 
 }
 
 dependencies {
     implementation project(':model')
+    implementation platform(libraries.kotlinBom)
     implementation libraries.kotlinStd
 
     //<DI>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,12 +8,12 @@ ext.versions = [
         buildTools           : '35.0.0',
 
         androidGradlePlugin  : '8.6.1',
-        kotlin               : '1.9.25',
+        kotlin               : '2.1.21',
         googleServicesVersion: '4.4.4',
         dexcount             : '1.0.3',
         firebasePerfPlugin   : '1.3.1',
 
-        dagger               : '2.51.1',
+        dagger               : '2.56.2',
 
         rxJava2              : '2.2.5',
         rxAndroid            : '2.1.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,12 +8,12 @@ ext.versions = [
         buildTools           : '35.0.0',
 
         androidGradlePlugin  : '8.6.1',
-        kotlin               : '1.7.10',
+        kotlin               : '1.9.25',
         googleServicesVersion: '4.4.4',
         dexcount             : '1.0.3',
         firebasePerfPlugin   : '1.3.1',
 
-        dagger               : '2.42',
+        dagger               : '2.51.1',
 
         rxJava2              : '2.2.5',
         rxAndroid            : '2.1.0',
@@ -126,6 +126,7 @@ ext.gradlePlugins = [
 ]
 
 ext.libraries = [
+        kotlinBom            : "org.jetbrains.kotlin:kotlin-bom:$versions.kotlin",
         kotlinStd            : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin",
 
         dagger               : "com.google.dagger:dagger:$versions.dagger",

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -22,11 +22,22 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     namespace 'org.stepik.android.model'
 
 }
 
 dependencies {
+    implementation platform(libraries.kotlinBom)
     implementation libraries.kotlinStd
     implementation libraries.gson
     implementation libraries.model


### PR DESCRIPTION
## Changes
- Bump Kotlin from 1.9.25 to 2.1.21 in dependencies.gradle.
- Bump Dagger from 2.51.1 to 2.56.2 so kapt can read Kotlin 2.1 metadata.
- Enable Dagger binding graph fix for the app kapt configuration.
- Move ViewModelProvider.Factory binding out of AppCoreModule into a reusable ViewModelFactoryModule.
- Include ViewModelFactoryModule in feature and debug presentation modules that contribute ViewModel multibindings, so each subcomponent resolves its own ViewModel map.

## Verification
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:assembleDebug
- ./gradlew :app:testDebugUnitTest

## Notes
- Existing local changes in docs/kotlin-migration/kotlin-1.9.25-migration-tracker.md were left out of this commit.