### PR TITLE
APPS-3853 Fix incorrect streak display

### DIFF
--- a/app/src/main/java/org/stepic/droid/core/presenters/HomeStreakPresenter.kt
+++ b/app/src/main/java/org/stepic/droid/core/presenters/HomeStreakPresenter.kt
@@ -10,10 +10,8 @@ import org.stepic.droid.di.home.HomeScope
 import org.stepic.droid.di.qualifiers.BackgroundScheduler
 import org.stepic.droid.di.qualifiers.MainScheduler
 import org.stepic.droid.preferences.SharedPreferenceHelper
-import org.stepic.droid.util.StepikUtil
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
 import ru.nobird.android.domain.rx.emptyOnErrorStub
-import ru.nobird.android.domain.rx.toMaybe
 import javax.inject.Inject
 
 @HomeScope
@@ -32,14 +30,8 @@ constructor(
     fun onNeedShowStreak() {
         compositeDisposable += Maybe
             .fromCallable { sharedPreferences.profile?.id }
-            .flatMapSingleElement(userActivityRepository::getUserActivities)
-            .flatMap { userActivities ->
-                userActivities
-                    .firstOrNull()
-                    ?.pins
-                    ?.let(StepikUtil::getCurrentStreak)
-                    .toMaybe()
-            }
+            .flatMapSingleElement(userActivityRepository::getUserActivitySummary)
+            .map { it.recentStrike }
             .subscribeOn(backgroundScheduler)
             .observeOn(mainScheduler)
             .subscribeBy(

--- a/app/src/main/java/org/stepic/droid/di/NotificationModule.kt
+++ b/app/src/main/java/org/stepic/droid/di/NotificationModule.kt
@@ -19,6 +19,7 @@ import org.stepik.android.view.purchase_notification.notification.PurchaseNotifi
 import org.stepik.android.view.splash.notification.RemindRegistrationNotificationDelegate
 import org.stepik.android.view.splash.notification.RetentionNotificationDelegate
 import org.stepik.android.view.streak.notification.StreakNotificationDelegate
+import org.stepik.android.view.streak.notification.StreakNotificationScheduler
 
 @Module(includes = [CourseDataModule::class])
 interface NotificationModule {
@@ -53,6 +54,9 @@ interface NotificationModule {
     @Binds
     @IntoSet
     fun provideStreakNotificationDelegate(streakNotificationDelegate: StreakNotificationDelegate): NotificationDelegate
+
+    @Binds
+    fun bindStreakNotificationScheduler(streakNotificationDelegate: StreakNotificationDelegate): StreakNotificationScheduler
 
     @Binds
     @IntoSet

--- a/app/src/main/java/org/stepik/android/data/user_activity/repository/UserActivityRepositoryImpl.kt
+++ b/app/src/main/java/org/stepik/android/data/user_activity/repository/UserActivityRepositoryImpl.kt
@@ -4,6 +4,7 @@ import io.reactivex.Single
 import org.stepik.android.data.user_activity.source.UserActivityRemoteDataSource
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
 import org.stepik.android.model.user.UserActivity
+import org.stepik.android.model.user.UserActivitySummary
 import javax.inject.Inject
 
 class UserActivityRepositoryImpl
@@ -14,4 +15,7 @@ constructor(
 
     override fun getUserActivities(userId: Long): Single<List<UserActivity>> =
         userActivityRemoteDataSource.getUserActivities(userId)
+
+    override fun getUserActivitySummary(userId: Long): Single<UserActivitySummary> =
+        userActivityRemoteDataSource.getUserActivitySummary(userId)
 }

--- a/app/src/main/java/org/stepik/android/data/user_activity/source/UserActivityRemoteDataSource.kt
+++ b/app/src/main/java/org/stepik/android/data/user_activity/source/UserActivityRemoteDataSource.kt
@@ -2,7 +2,10 @@ package org.stepik.android.data.user_activity.source
 
 import io.reactivex.Single
 import org.stepik.android.model.user.UserActivity
+import org.stepik.android.model.user.UserActivitySummary
 
 interface UserActivityRemoteDataSource {
     fun getUserActivities(userId: Long): Single<List<UserActivity>>
+
+    fun getUserActivitySummary(userId: Long): Single<UserActivitySummary>
 }

--- a/app/src/main/java/org/stepik/android/domain/profile_activities/interactor/ProfileActivitiesInteractor.kt
+++ b/app/src/main/java/org/stepik/android/domain/profile_activities/interactor/ProfileActivitiesInteractor.kt
@@ -3,10 +3,8 @@ package org.stepik.android.domain.profile_activities.interactor
 import io.reactivex.Single
 import org.stepik.android.domain.profile_activities.model.ProfileActivitiesData
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
-import org.stepik.android.model.user.UserActivity
-import ru.nobird.android.domain.rx.first
+import org.stepik.android.model.user.UserActivitySummary
 import javax.inject.Inject
-import kotlin.math.max
 
 class ProfileActivitiesInteractor
 @Inject
@@ -15,28 +13,14 @@ constructor(
 ) {
     fun getProfileActivities(userId: Long): Single<ProfileActivitiesData> =
         userActivityRepository
-            .getUserActivities(userId)
-            .first()
+            .getUserActivitySummary(userId)
             .map(::mapToProfileActivities)
 
-    private fun mapToProfileActivities(userActivity: UserActivity): ProfileActivitiesData {
-        var streak = 0
-        var maxStreak = 0
-        var buffer = 0
-
-        for (i in 0..userActivity.pins.size) {
-            val pin = userActivity.pins.getOrElse(i) { 0 }
-            if (pin > 0) {
-                buffer++
-            } else {
-                maxStreak = max(maxStreak, buffer)
-                if (buffer == i || buffer == i - 1) { // first is solved today, second not solved
-                    streak = buffer
-                }
-                buffer = 0
-            }
-        }
-
-        return ProfileActivitiesData(userActivity.pins, streak, maxStreak, isSolvedToday = userActivity.pins[0] > 0)
-    }
+    private fun mapToProfileActivities(userActivitySummary: UserActivitySummary): ProfileActivitiesData =
+        ProfileActivitiesData(
+            pins = userActivitySummary.pins,
+            streak = userActivitySummary.recentStrike,
+            maxStreak = userActivitySummary.maxStrike,
+            isSolvedToday = userActivitySummary.solvedToday > 0
+        )
 }

--- a/app/src/main/java/org/stepik/android/domain/streak/interactor/StreakInteractor.kt
+++ b/app/src/main/java/org/stepik/android/domain/streak/interactor/StreakInteractor.kt
@@ -3,7 +3,7 @@ package org.stepik.android.domain.streak.interactor
 import io.reactivex.Maybe
 import org.stepic.droid.preferences.SharedPreferenceHelper
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
-import org.stepik.android.view.streak.notification.StreakNotificationDelegate
+import org.stepik.android.view.streak.notification.StreakNotificationScheduler
 import javax.inject.Inject
 
 class StreakInteractor
@@ -11,7 +11,7 @@ class StreakInteractor
 constructor(
     private val userActivityRepository: UserActivityRepository,
     private val sharedPreferenceHelper: SharedPreferenceHelper,
-    private val streakNotificationDelegate: StreakNotificationDelegate
+    private val streakNotificationScheduler: StreakNotificationScheduler
 ) {
 
     fun needShowStreakDialog(): Boolean =
@@ -28,7 +28,7 @@ constructor(
     fun setStreakTime(timeIntervalCode: Int) {
         sharedPreferenceHelper.isStreakNotificationEnabled = true
         sharedPreferenceHelper.timeNotificationCode = timeIntervalCode
-        streakNotificationDelegate.scheduleStreakNotification()
+        streakNotificationScheduler.scheduleStreakNotification()
     }
 
     fun wasStreakDialogSeenOnHomeScreen(): Boolean =

--- a/app/src/main/java/org/stepik/android/domain/streak/interactor/StreakInteractor.kt
+++ b/app/src/main/java/org/stepik/android/domain/streak/interactor/StreakInteractor.kt
@@ -2,8 +2,6 @@ package org.stepik.android.domain.streak.interactor
 
 import io.reactivex.Maybe
 import org.stepic.droid.preferences.SharedPreferenceHelper
-import org.stepic.droid.util.StepikUtil
-import ru.nobird.android.domain.rx.toMaybe
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
 import org.stepik.android.view.streak.notification.StreakNotificationDelegate
 import javax.inject.Inject
@@ -24,9 +22,8 @@ constructor(
     fun onNeedShowStreak(): Maybe<Int> =
         Maybe
             .fromCallable { sharedPreferenceHelper.profile?.id }
-            .flatMapSingleElement { userActivityRepository.getUserActivities(it) }
-            .flatMap { it.firstOrNull()?.pins.toMaybe() }
-            .map { StepikUtil.getCurrentStreak(it) }
+            .flatMapSingleElement { userActivityRepository.getUserActivitySummary(it) }
+            .map { it.recentStrike }
 
     fun setStreakTime(timeIntervalCode: Int) {
         sharedPreferenceHelper.isStreakNotificationEnabled = true

--- a/app/src/main/java/org/stepik/android/domain/user_activity/repository/UserActivityRepository.kt
+++ b/app/src/main/java/org/stepik/android/domain/user_activity/repository/UserActivityRepository.kt
@@ -2,7 +2,10 @@ package org.stepik.android.domain.user_activity.repository
 
 import io.reactivex.Single
 import org.stepik.android.model.user.UserActivity
+import org.stepik.android.model.user.UserActivitySummary
 
 interface UserActivityRepository {
     fun getUserActivities(userId: Long): Single<List<UserActivity>>
+
+    fun getUserActivitySummary(userId: Long): Single<UserActivitySummary>
 }

--- a/app/src/main/java/org/stepik/android/remote/user_activity/UserActivityRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/stepik/android/remote/user_activity/UserActivityRemoteDataSourceImpl.kt
@@ -4,7 +4,9 @@ import io.reactivex.Single
 import io.reactivex.functions.Function
 import org.stepik.android.data.user_activity.source.UserActivityRemoteDataSource
 import org.stepik.android.model.user.UserActivity
+import org.stepik.android.model.user.UserActivitySummary
 import org.stepik.android.remote.user_activity.model.UserActivityResponse
+import org.stepik.android.remote.user_activity.model.UserActivitySummaryResponse
 import org.stepik.android.remote.user_activity.service.UserActivityService
 import javax.inject.Inject
 
@@ -16,8 +18,16 @@ constructor(
     private val userActivityResponseMapper =
         Function<UserActivityResponse, List<UserActivity>>(UserActivityResponse::userActivities)
 
+    private val userActivitySummaryResponseMapper =
+        Function<UserActivitySummaryResponse, UserActivitySummary> { it.userActivitySummaries.first() }
+
     override fun getUserActivities(userId: Long): Single<List<UserActivity>> =
         userActivityService
             .getUserActivitiesReactive(userId)
             .map(userActivityResponseMapper)
+
+    override fun getUserActivitySummary(userId: Long): Single<UserActivitySummary> =
+        userActivityService
+            .getUserActivitySummaryReactive(userId)
+            .map(userActivitySummaryResponseMapper)
 }

--- a/app/src/main/java/org/stepik/android/remote/user_activity/model/UserActivitySummaryResponse.kt
+++ b/app/src/main/java/org/stepik/android/remote/user_activity/model/UserActivitySummaryResponse.kt
@@ -1,0 +1,13 @@
+package org.stepik.android.remote.user_activity.model
+
+import com.google.gson.annotations.SerializedName
+import org.stepik.android.model.Meta
+import org.stepik.android.model.user.UserActivitySummary
+import org.stepik.android.remote.base.model.MetaResponse
+
+class UserActivitySummaryResponse(
+    @SerializedName("meta")
+    override val meta: Meta,
+    @SerializedName("user-activity-summaries")
+    val userActivitySummaries: List<UserActivitySummary>
+) : MetaResponse

--- a/app/src/main/java/org/stepik/android/remote/user_activity/service/UserActivityService.kt
+++ b/app/src/main/java/org/stepik/android/remote/user_activity/service/UserActivityService.kt
@@ -2,10 +2,14 @@ package org.stepik.android.remote.user_activity.service
 
 import io.reactivex.Single
 import org.stepik.android.remote.user_activity.model.UserActivityResponse
+import org.stepik.android.remote.user_activity.model.UserActivitySummaryResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface UserActivityService {
     @GET("api/user-activities/{userId}")
     fun getUserActivitiesReactive(@Path("userId") userId: Long): Single<UserActivityResponse>
+
+    @GET("api/user-activity-summaries/{userId}")
+    fun getUserActivitySummaryReactive(@Path("userId") userId: Long): Single<UserActivitySummaryResponse>
 }

--- a/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationDelegate.kt
@@ -35,7 +35,7 @@ constructor(
     private val sharedPreferenceHelper: SharedPreferenceHelper,
     private val notificationHelper: NotificationHelper,
     stepikNotificationManager: StepikNotificationManager
-) : NotificationDelegate("show_streak_notification", stepikNotificationManager) {
+) : NotificationDelegate("show_streak_notification", stepikNotificationManager), StreakNotificationScheduler {
     companion object {
         const val STREAK_NOTIFICATION_CLICKED = "streak_notification_clicked"
         private const val STREAK_NOTIFICATION_ID = 3214L
@@ -92,7 +92,7 @@ constructor(
         }
     }
 
-    fun scheduleStreakNotification() {
+    override fun scheduleStreakNotification() {
         if (sharedPreferenceHelper.isStreakNotificationEnabled) {
             // plan new alarm
             val hour = sharedPreferenceHelper.timeNotificationCode

--- a/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationDelegate.kt
+++ b/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationDelegate.kt
@@ -9,7 +9,6 @@ import org.stepic.droid.core.ScreenManager
 import org.stepic.droid.preferences.SharedPreferenceHelper
 import org.stepic.droid.util.AppConstants
 import org.stepic.droid.util.DateTimeHelper
-import org.stepic.droid.util.StepikUtil
 import org.stepik.android.domain.base.analytic.BUNDLEABLE_ANALYTIC_EVENT
 import org.stepik.android.domain.base.analytic.toBundle
 import org.stepik.android.domain.streak.analytic.StreakNotificationClicked
@@ -48,23 +47,35 @@ constructor(
             val numberOfStreakNotifications = sharedPreferenceHelper.numberOfStreakNotifications
             if (numberOfStreakNotifications < AppConstants.MAX_NUMBER_OF_NOTIFICATION_STREAK) {
                 try {
-                    val pins: ArrayList<Long> = userActivityRepository.getUserActivities(sharedPreferenceHelper.profile?.id ?: throw Exception("User is not auth"))
+                    val userId = sharedPreferenceHelper.profile?.id
+                        ?: throw Exception("User is not auth")
+                    val userActivitySummary = userActivityRepository
+                        .getUserActivitySummary(userId)
                         .blockingGet()
-                        .firstOrNull()
-                        ?.pins!!
-                    val (currentStreak, isSolvedToday) = StepikUtil.getCurrentStreakExtended(pins)
-                    if (currentStreak <= 0) {
-                        analytic.reportEvent(Analytic.Streak.GET_ZERO_STREAK_NOTIFICATION)
-                        showNotificationWithoutStreakInfo(StreakNotificationType.ZERO)
-                    } else {
-                        // if current streak is > 0 -> streaks works! -> continue send it
-                        // it will reset before sending, after sending it will be incremented
-                        sharedPreferenceHelper.resetNumberOfStreakNotifications()
-                        if (isSolvedToday) {
-                            showNotificationStreakImprovement(currentStreak)
-                        } else {
-                            showNotificationWithStreakCallToAction(currentStreak)
+
+                    val notificationType = getStreakNotificationType(
+                        userActivitySummary.recentStrike,
+                        userActivitySummary.solvedToday
+                    )
+
+                    when (notificationType) {
+                        StreakNotificationType.ZERO -> {
+                            analytic.reportEvent(Analytic.Streak.GET_ZERO_STREAK_NOTIFICATION)
+                            showNotificationWithoutStreakInfo(StreakNotificationType.ZERO)
                         }
+
+                        StreakNotificationType.SOLVED_TODAY -> {
+                            sharedPreferenceHelper.resetNumberOfStreakNotifications()
+                            showNotificationStreakImprovement(userActivitySummary.recentStrike)
+                        }
+
+                        StreakNotificationType.NOT_SOLVED_TODAY -> {
+                            sharedPreferenceHelper.resetNumberOfStreakNotifications()
+                            showNotificationWithStreakCallToAction(userActivitySummary.recentStrike)
+                        }
+
+                        StreakNotificationType.NO_INTERNET ->
+                            Unit
                     }
                 } catch (exception: Exception) {
                     // no internet || cant get streaks -> show some notification without streak information.
@@ -158,3 +169,13 @@ constructor(
         return PendingIntentCompat.getBroadcast(context, 0, deleteIntent, PendingIntent.FLAG_CANCEL_CURRENT)
     }
 }
+
+internal fun getStreakNotificationType(recentStrike: Int, solvedToday: Int): StreakNotificationType =
+    when {
+        recentStrike <= 0 ->
+            StreakNotificationType.ZERO
+        solvedToday > 0 ->
+            StreakNotificationType.SOLVED_TODAY
+        else ->
+            StreakNotificationType.NOT_SOLVED_TODAY
+    }

--- a/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationScheduler.kt
+++ b/app/src/main/java/org/stepik/android/view/streak/notification/StreakNotificationScheduler.kt
@@ -1,0 +1,5 @@
+package org.stepik.android.view.streak.notification
+
+interface StreakNotificationScheduler {
+    fun scheduleStreakNotification()
+}

--- a/app/src/test/java/org/stepic/droid/core/presenters/HomeStreakPresenterTest.kt
+++ b/app/src/test/java/org/stepic/droid/core/presenters/HomeStreakPresenterTest.kt
@@ -1,55 +1,72 @@
 package org.stepic.droid.core.presenters
 
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.stepic.droid.core.presenters.contracts.HomeStreakView
 import org.stepic.droid.preferences.SharedPreferenceHelper
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
 import org.stepik.android.model.user.Profile
+import org.stepik.android.model.user.UserActivity
 import org.stepik.android.model.user.UserActivitySummary
 
-@RunWith(MockitoJUnitRunner::class)
 class HomeStreakPresenterTest {
-    @Mock
-    private lateinit var userActivityRepository: UserActivityRepository
-
-    @Mock
-    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
-
-    @Mock
-    private lateinit var homeStreakView: HomeStreakView
-
     @Test
     fun `home streak displays recent strike above pins limit`() {
-        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
-        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(
-                recentStrike = RECENT_STRIKE,
-                solvedToday = 0,
-                pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
-            )
-        )
-
+        val view = FakeHomeStreakView()
         val presenter = HomeStreakPresenter(
             backgroundScheduler = Schedulers.trampoline(),
             mainScheduler = Schedulers.trampoline(),
-            userActivityRepository = userActivityRepository,
-            sharedPreferences = sharedPreferenceHelper
+            userActivityRepository = FakeUserActivityRepository(
+                UserActivitySummary(
+                    recentStrike = RECENT_STRIKE,
+                    solvedToday = 0,
+                    pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+                )
+            ),
+            sharedPreferences = TestSharedPreferenceHelper(Profile(id = USER_ID))
         )
 
-        presenter.attachView(homeStreakView)
+        presenter.attachView(view)
         presenter.onNeedShowStreak()
 
-        verify(homeStreakView).showStreak(RECENT_STRIKE)
-        verify(homeStreakView, never()).onEmptyStreak()
+        assertEquals(RECENT_STRIKE, view.shownStreak)
+        assertFalse(view.isEmptyStreakShown)
+    }
+
+    private class FakeHomeStreakView : HomeStreakView {
+        var shownStreak: Int? = null
+            private set
+
+        var isEmptyStreakShown: Boolean = false
+            private set
+
+        override fun showStreak(streak: Int) {
+            shownStreak = streak
+        }
+
+        override fun onEmptyStreak() {
+            isEmptyStreakShown = true
+        }
+    }
+
+    private class FakeUserActivityRepository(
+        private val summary: UserActivitySummary
+    ) : UserActivityRepository {
+        override fun getUserActivities(userId: Long): Single<List<UserActivity>> =
+            Single.error(UnsupportedOperationException("Legacy user activities should not be used"))
+
+        override fun getUserActivitySummary(userId: Long): Single<UserActivitySummary> =
+            Single.just(summary)
+    }
+
+    private class TestSharedPreferenceHelper(
+        private val profile: Profile
+    ) : SharedPreferenceHelper(null, null, null, null) {
+        override fun getProfile(): Profile =
+            profile
     }
 
     private companion object {

--- a/app/src/test/java/org/stepic/droid/core/presenters/HomeStreakPresenterTest.kt
+++ b/app/src/test/java/org/stepic/droid/core/presenters/HomeStreakPresenterTest.kt
@@ -1,0 +1,59 @@
+package org.stepic.droid.core.presenters
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.stepic.droid.core.presenters.contracts.HomeStreakView
+import org.stepic.droid.preferences.SharedPreferenceHelper
+import org.stepik.android.domain.user_activity.repository.UserActivityRepository
+import org.stepik.android.model.user.Profile
+import org.stepik.android.model.user.UserActivitySummary
+
+@RunWith(MockitoJUnitRunner::class)
+class HomeStreakPresenterTest {
+    @Mock
+    private lateinit var userActivityRepository: UserActivityRepository
+
+    @Mock
+    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
+
+    @Mock
+    private lateinit var homeStreakView: HomeStreakView
+
+    @Test
+    fun `home streak displays recent strike above pins limit`() {
+        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
+            UserActivitySummary(
+                recentStrike = RECENT_STRIKE,
+                solvedToday = 0,
+                pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+            )
+        )
+
+        val presenter = HomeStreakPresenter(
+            backgroundScheduler = Schedulers.trampoline(),
+            mainScheduler = Schedulers.trampoline(),
+            userActivityRepository = userActivityRepository,
+            sharedPreferences = sharedPreferenceHelper
+        )
+
+        presenter.attachView(homeStreakView)
+        presenter.onNeedShowStreak()
+
+        verify(homeStreakView).showStreak(RECENT_STRIKE)
+        verify(homeStreakView, never()).onEmptyStreak()
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        const val RECENT_STRIKE = 380
+    }
+}

--- a/app/src/test/java/org/stepik/android/domain/auth/mapper/SocialConsentMapperTest.kt
+++ b/app/src/test/java/org/stepik/android/domain/auth/mapper/SocialConsentMapperTest.kt
@@ -63,9 +63,9 @@ class SocialConsentMapperTest {
             isMarketingVisible = true,
             isMarketingChecked = true
         )
-        val result = mapper.mapConsent(state, SocialNetwork.TWITTER)
+        val result = mapper.mapConsent(state, SocialNetwork.GITHUB)
         assertTrue(result is SocialConsentResult.Valid)
-        assertEquals(SocialNetwork.TWITTER, (result as SocialConsentResult.Valid).provider)
+        assertEquals(SocialNetwork.GITHUB, (result as SocialConsentResult.Valid).provider)
     }
 
     // AC3: Marketing Hidden Clears Pending Consent
@@ -132,13 +132,6 @@ class SocialConsentMapperTest {
         val state = validConsentState()
         val result = mapper.mapConsent(state, SocialNetwork.VK) as SocialConsentResult.Valid
         assertEquals(SocialNetwork.VK, result.provider)
-    }
-
-    @Test
-    fun `twitter provider is preserved in valid result`() {
-        val state = validConsentState()
-        val result = mapper.mapConsent(state, SocialNetwork.TWITTER) as SocialConsentResult.Valid
-        assertEquals(SocialNetwork.TWITTER, result.provider)
     }
 
     @Test

--- a/app/src/test/java/org/stepik/android/domain/profile_activities/interactor/ProfileActivitiesInteractorTest.kt
+++ b/app/src/test/java/org/stepik/android/domain/profile_activities/interactor/ProfileActivitiesInteractorTest.kt
@@ -1,0 +1,89 @@
+package org.stepik.android.domain.profile_activities.interactor
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Single
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.stepik.android.domain.profile_activities.model.ProfileActivitiesData
+import org.stepik.android.domain.user_activity.repository.UserActivityRepository
+import org.stepik.android.model.user.UserActivitySummary
+
+@RunWith(MockitoJUnitRunner::class)
+class ProfileActivitiesInteractorTest {
+    @Mock
+    private lateinit var userActivityRepository: UserActivityRepository
+
+    @Test
+    fun `summary without solved today maps to continue streak data`() {
+        val pins = listOf(0L, 2L, 1L, 3L, 0L, 1L, 4L)
+        val summary = UserActivitySummary(
+            recentStrike = 377,
+            solvedToday = 0,
+            maxStrike = 412,
+            pins = pins
+        )
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(summary)
+
+        ProfileActivitiesInteractor(userActivityRepository)
+            .getProfileActivities(USER_ID)
+            .test()
+            .assertComplete()
+            .assertResult(
+                ProfileActivitiesData(pins, streak = 377, maxStreak = 412, isSolvedToday = false)
+            )
+
+        verify(userActivityRepository).getUserActivitySummary(USER_ID)
+    }
+
+    @Test
+    fun `summary with solved today maps to active streak data`() {
+        val pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+        val summary = UserActivitySummary(
+            recentStrike = 378,
+            solvedToday = 2,
+            maxStrike = 412,
+            pins = pins
+        )
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(summary)
+
+        ProfileActivitiesInteractor(userActivityRepository)
+            .getProfileActivities(USER_ID)
+            .test()
+            .assertComplete()
+            .assertResult(
+                ProfileActivitiesData(pins, streak = 378, maxStreak = 412, isSolvedToday = true)
+            )
+
+        verify(userActivityRepository).getUserActivitySummary(USER_ID)
+    }
+
+    @Test
+    fun `zero summary maps to start streak data`() {
+        val pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+        val summary = UserActivitySummary(
+            recentStrike = 0,
+            solvedToday = 0,
+            maxStrike = 0,
+            pins = pins
+        )
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(summary)
+
+        ProfileActivitiesInteractor(userActivityRepository)
+            .getProfileActivities(USER_ID)
+            .test()
+            .assertComplete()
+            .assertResult(
+                ProfileActivitiesData(pins, streak = 0, maxStreak = 0, isSolvedToday = false)
+            )
+
+        verify(userActivityRepository).getUserActivitySummary(USER_ID)
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+    }
+}

--- a/app/src/test/java/org/stepik/android/domain/streak/interactor/StreakInteractorTest.kt
+++ b/app/src/test/java/org/stepik/android/domain/streak/interactor/StreakInteractorTest.kt
@@ -1,85 +1,53 @@
 package org.stepik.android.domain.streak.interactor
 
-import android.content.Context
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.MockitoAnnotations
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import org.stepic.droid.analytic.Analytic
-import org.stepic.droid.core.ScreenManager
 import org.stepic.droid.preferences.SharedPreferenceHelper
 import org.stepik.android.domain.user_activity.repository.UserActivityRepository
 import org.stepik.android.model.user.Profile
+import org.stepik.android.model.user.UserActivity
 import org.stepik.android.model.user.UserActivitySummary
-import org.stepik.android.view.notification.StepikNotificationManager
-import org.stepik.android.view.notification.helpers.NotificationHelper
-import org.stepik.android.view.streak.notification.StreakNotificationDelegate
+import org.stepik.android.view.streak.notification.StreakNotificationScheduler
 
-@RunWith(RobolectricTestRunner::class)
 class StreakInteractorTest {
-    @Mock
-    private lateinit var userActivityRepository: UserActivityRepository
-
-    @Mock
-    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
-
-    @Mock
-    private lateinit var analytic: Analytic
-
-    @Mock
-    private lateinit var screenManager: ScreenManager
-
-    @Mock
-    private lateinit var notificationHelper: NotificationHelper
-
-    @Mock
-    private lateinit var stepikNotificationManager: StepikNotificationManager
-
-    private lateinit var context: Context
-    private lateinit var streakNotificationDelegate: StreakNotificationDelegate
-
-    @Before
-    fun setUp() {
-        MockitoAnnotations.initMocks(this)
-
-        context = RuntimeEnvironment.getApplication()
-        streakNotificationDelegate = StreakNotificationDelegate(
-            context = context,
-            analytic = analytic,
-            userActivityRepository = userActivityRepository,
-            screenManager = screenManager,
-            sharedPreferenceHelper = sharedPreferenceHelper,
-            notificationHelper = notificationHelper,
-            stepikNotificationManager = stepikNotificationManager
-        )
-    }
-
     @Test
     fun `on need show streak returns recent strike above pins limit`() {
-        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
-        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(
-                recentStrike = RECENT_STRIKE,
-                solvedToday = 0,
-                pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
-            )
-        )
-
         StreakInteractor(
-            userActivityRepository = userActivityRepository,
-            sharedPreferenceHelper = sharedPreferenceHelper,
-            streakNotificationDelegate = streakNotificationDelegate
+            userActivityRepository = FakeUserActivityRepository(
+                UserActivitySummary(
+                    recentStrike = RECENT_STRIKE,
+                    solvedToday = 0,
+                    pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+                )
+            ),
+            sharedPreferenceHelper = TestSharedPreferenceHelper(Profile(id = USER_ID)),
+            streakNotificationScheduler = FakeStreakNotificationScheduler()
         )
             .onNeedShowStreak()
             .test()
             .assertComplete()
             .assertResult(RECENT_STRIKE)
+    }
+
+    private class FakeUserActivityRepository(
+        private val summary: UserActivitySummary
+    ) : UserActivityRepository {
+        override fun getUserActivities(userId: Long): Single<List<UserActivity>> =
+            Single.error(UnsupportedOperationException("Legacy user activities should not be used"))
+
+        override fun getUserActivitySummary(userId: Long): Single<UserActivitySummary> =
+            Single.just(summary)
+    }
+
+    private class TestSharedPreferenceHelper(
+        private val profile: Profile
+    ) : SharedPreferenceHelper(null, null, null, null) {
+        override fun getProfile(): Profile =
+            profile
+    }
+
+    private class FakeStreakNotificationScheduler : StreakNotificationScheduler {
+        override fun scheduleStreakNotification() {}
     }
 
     private companion object {

--- a/app/src/test/java/org/stepik/android/domain/streak/interactor/StreakInteractorTest.kt
+++ b/app/src/test/java/org/stepik/android/domain/streak/interactor/StreakInteractorTest.kt
@@ -1,0 +1,89 @@
+package org.stepik.android.domain.streak.interactor
+
+import android.content.Context
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Single
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.stepic.droid.analytic.Analytic
+import org.stepic.droid.core.ScreenManager
+import org.stepic.droid.preferences.SharedPreferenceHelper
+import org.stepik.android.domain.user_activity.repository.UserActivityRepository
+import org.stepik.android.model.user.Profile
+import org.stepik.android.model.user.UserActivitySummary
+import org.stepik.android.view.notification.StepikNotificationManager
+import org.stepik.android.view.notification.helpers.NotificationHelper
+import org.stepik.android.view.streak.notification.StreakNotificationDelegate
+
+@RunWith(RobolectricTestRunner::class)
+class StreakInteractorTest {
+    @Mock
+    private lateinit var userActivityRepository: UserActivityRepository
+
+    @Mock
+    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
+
+    @Mock
+    private lateinit var analytic: Analytic
+
+    @Mock
+    private lateinit var screenManager: ScreenManager
+
+    @Mock
+    private lateinit var notificationHelper: NotificationHelper
+
+    @Mock
+    private lateinit var stepikNotificationManager: StepikNotificationManager
+
+    private lateinit var context: Context
+    private lateinit var streakNotificationDelegate: StreakNotificationDelegate
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        context = RuntimeEnvironment.getApplication()
+        streakNotificationDelegate = StreakNotificationDelegate(
+            context = context,
+            analytic = analytic,
+            userActivityRepository = userActivityRepository,
+            screenManager = screenManager,
+            sharedPreferenceHelper = sharedPreferenceHelper,
+            notificationHelper = notificationHelper,
+            stepikNotificationManager = stepikNotificationManager
+        )
+    }
+
+    @Test
+    fun `on need show streak returns recent strike above pins limit`() {
+        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
+            UserActivitySummary(
+                recentStrike = RECENT_STRIKE,
+                solvedToday = 0,
+                pins = listOf(0L, 0L, 0L, 0L, 0L, 0L, 0L)
+            )
+        )
+
+        StreakInteractor(
+            userActivityRepository = userActivityRepository,
+            sharedPreferenceHelper = sharedPreferenceHelper,
+            streakNotificationDelegate = streakNotificationDelegate
+        )
+            .onNeedShowStreak()
+            .test()
+            .assertComplete()
+            .assertResult(RECENT_STRIKE)
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        const val RECENT_STRIKE = 380
+    }
+}

--- a/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
+++ b/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
@@ -95,7 +95,7 @@ class StreakNotificationDelegateTest {
     @Test
     fun `positive recent strike with solved today sends improvement notification`() {
         whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(recentStrike = 10, solvedToday = 1)
+            UserActivitySummary(recentStrike = 381, solvedToday = 1)
         )
 
         streakNotificationDelegate.onNeedShowNotification()
@@ -107,7 +107,7 @@ class StreakNotificationDelegateTest {
     @Test
     fun `positive recent strike without solved today sends call to action notification`() {
         whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(recentStrike = 10, solvedToday = 0)
+            UserActivitySummary(recentStrike = 380, solvedToday = 0)
         )
 
         streakNotificationDelegate.onNeedShowNotification()

--- a/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
+++ b/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
@@ -1,0 +1,134 @@
+package org.stepik.android.view.streak.notification
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Single
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.stepic.droid.R
+import org.stepic.droid.analytic.Analytic
+import org.stepic.droid.core.ScreenManager
+import org.stepic.droid.preferences.SharedPreferenceHelper
+import org.stepik.android.domain.base.analytic.AnalyticEvent
+import org.stepik.android.domain.user_activity.repository.UserActivityRepository
+import org.stepik.android.model.user.Profile
+import org.stepik.android.model.user.UserActivitySummary
+import org.stepik.android.view.notification.StepikNotificationManager
+import org.stepik.android.view.notification.helpers.NotificationHelper
+import org.stepik.android.view.streak.model.StreakNotificationType
+
+@RunWith(RobolectricTestRunner::class)
+class StreakNotificationDelegateTest {
+    @Mock
+    private lateinit var analytic: Analytic
+
+    @Mock
+    private lateinit var userActivityRepository: UserActivityRepository
+
+    @Mock
+    private lateinit var screenManager: ScreenManager
+
+    @Mock
+    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
+
+    @Mock
+    private lateinit var notificationHelper: NotificationHelper
+
+    @Mock
+    private lateinit var stepikNotificationManager: StepikNotificationManager
+
+    private lateinit var context: Context
+    private lateinit var streakNotificationDelegate: StreakNotificationDelegate
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        context = RuntimeEnvironment.getApplication()
+        streakNotificationDelegate = StreakNotificationDelegate(
+            context = context,
+            analytic = analytic,
+            userActivityRepository = userActivityRepository,
+            screenManager = screenManager,
+            sharedPreferenceHelper = sharedPreferenceHelper,
+            notificationHelper = notificationHelper,
+            stepikNotificationManager = stepikNotificationManager
+        )
+
+        whenever(sharedPreferenceHelper.isStreakNotificationEnabled) doReturn true
+        whenever(sharedPreferenceHelper.numberOfStreakNotifications) doReturn 0
+        whenever(sharedPreferenceHelper.timeNotificationCode) doReturn 12
+        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
+        whenever(screenManager.getMyCoursesIntent(context)) doReturn Intent("test")
+        whenever(notificationHelper.makeSimpleNotificationBuilder(any(), any(), any(), any(), any(), any())) doReturn
+            NotificationCompat.Builder(context, "test")
+                .setSmallIcon(R.drawable.ic_player_notification)
+    }
+
+    @Test
+    fun `recent strike less than or equal to zero sends zero streak notification`() {
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
+            UserActivitySummary(recentStrike = 0, solvedToday = 0)
+        )
+
+        streakNotificationDelegate.onNeedShowNotification()
+
+        verify(analytic).reportEvent(Analytic.Streak.GET_ZERO_STREAK_NOTIFICATION)
+        verify(sharedPreferenceHelper, never()).resetNumberOfStreakNotifications()
+        verifyNotificationShown(StreakNotificationType.ZERO)
+    }
+
+    @Test
+    fun `positive recent strike with solved today sends improvement notification`() {
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
+            UserActivitySummary(recentStrike = 10, solvedToday = 1)
+        )
+
+        streakNotificationDelegate.onNeedShowNotification()
+
+        verify(sharedPreferenceHelper).resetNumberOfStreakNotifications()
+        verifyNotificationShown(StreakNotificationType.SOLVED_TODAY)
+    }
+
+    @Test
+    fun `positive recent strike without solved today sends call to action notification`() {
+        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
+            UserActivitySummary(recentStrike = 10, solvedToday = 0)
+        )
+
+        streakNotificationDelegate.onNeedShowNotification()
+
+        verify(sharedPreferenceHelper).resetNumberOfStreakNotifications()
+        verifyNotificationShown(StreakNotificationType.NOT_SOLVED_TODAY)
+    }
+
+    private fun verifyNotificationShown(notificationType: StreakNotificationType) {
+        val analyticEventCaptor = argumentCaptor<AnalyticEvent>()
+
+        verify(analytic).report(analyticEventCaptor.capture())
+        assertEquals(
+            notificationType.type,
+            analyticEventCaptor.firstValue.params["type"]
+        )
+        verify(stepikNotificationManager).showNotification(eq(STREAK_NOTIFICATION_ID), any())
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        const val STREAK_NOTIFICATION_ID = 3214L
+    }
+}

--- a/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
+++ b/app/src/test/java/org/stepik/android/view/streak/notification/StreakNotificationDelegateTest.kt
@@ -1,134 +1,35 @@
 package org.stepik.android.view.streak.notification
 
-import android.content.Context
-import android.content.Intent
-import androidx.core.app.NotificationCompat
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
-import io.reactivex.Single
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.MockitoAnnotations
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import org.stepic.droid.R
-import org.stepic.droid.analytic.Analytic
-import org.stepic.droid.core.ScreenManager
-import org.stepic.droid.preferences.SharedPreferenceHelper
-import org.stepik.android.domain.base.analytic.AnalyticEvent
-import org.stepik.android.domain.user_activity.repository.UserActivityRepository
-import org.stepik.android.model.user.Profile
-import org.stepik.android.model.user.UserActivitySummary
-import org.stepik.android.view.notification.StepikNotificationManager
-import org.stepik.android.view.notification.helpers.NotificationHelper
 import org.stepik.android.view.streak.model.StreakNotificationType
 
-@RunWith(RobolectricTestRunner::class)
 class StreakNotificationDelegateTest {
-    @Mock
-    private lateinit var analytic: Analytic
-
-    @Mock
-    private lateinit var userActivityRepository: UserActivityRepository
-
-    @Mock
-    private lateinit var screenManager: ScreenManager
-
-    @Mock
-    private lateinit var sharedPreferenceHelper: SharedPreferenceHelper
-
-    @Mock
-    private lateinit var notificationHelper: NotificationHelper
-
-    @Mock
-    private lateinit var stepikNotificationManager: StepikNotificationManager
-
-    private lateinit var context: Context
-    private lateinit var streakNotificationDelegate: StreakNotificationDelegate
-
-    @Before
-    fun setUp() {
-        MockitoAnnotations.initMocks(this)
-
-        context = RuntimeEnvironment.getApplication()
-        streakNotificationDelegate = StreakNotificationDelegate(
-            context = context,
-            analytic = analytic,
-            userActivityRepository = userActivityRepository,
-            screenManager = screenManager,
-            sharedPreferenceHelper = sharedPreferenceHelper,
-            notificationHelper = notificationHelper,
-            stepikNotificationManager = stepikNotificationManager
-        )
-
-        whenever(sharedPreferenceHelper.isStreakNotificationEnabled) doReturn true
-        whenever(sharedPreferenceHelper.numberOfStreakNotifications) doReturn 0
-        whenever(sharedPreferenceHelper.timeNotificationCode) doReturn 12
-        whenever(sharedPreferenceHelper.profile) doReturn Profile(id = USER_ID)
-        whenever(screenManager.getMyCoursesIntent(context)) doReturn Intent("test")
-        whenever(notificationHelper.makeSimpleNotificationBuilder(any(), any(), any(), any(), any(), any())) doReturn
-            NotificationCompat.Builder(context, "test")
-                .setSmallIcon(R.drawable.ic_player_notification)
-    }
-
     @Test
-    fun `recent strike less than or equal to zero sends zero streak notification`() {
-        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(recentStrike = 0, solvedToday = 0)
-        )
-
-        streakNotificationDelegate.onNeedShowNotification()
-
-        verify(analytic).reportEvent(Analytic.Streak.GET_ZERO_STREAK_NOTIFICATION)
-        verify(sharedPreferenceHelper, never()).resetNumberOfStreakNotifications()
-        verifyNotificationShown(StreakNotificationType.ZERO)
-    }
-
-    @Test
-    fun `positive recent strike with solved today sends improvement notification`() {
-        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(recentStrike = 381, solvedToday = 1)
-        )
-
-        streakNotificationDelegate.onNeedShowNotification()
-
-        verify(sharedPreferenceHelper).resetNumberOfStreakNotifications()
-        verifyNotificationShown(StreakNotificationType.SOLVED_TODAY)
-    }
-
-    @Test
-    fun `positive recent strike without solved today sends call to action notification`() {
-        whenever(userActivityRepository.getUserActivitySummary(USER_ID)) doReturn Single.just(
-            UserActivitySummary(recentStrike = 380, solvedToday = 0)
-        )
-
-        streakNotificationDelegate.onNeedShowNotification()
-
-        verify(sharedPreferenceHelper).resetNumberOfStreakNotifications()
-        verifyNotificationShown(StreakNotificationType.NOT_SOLVED_TODAY)
-    }
-
-    private fun verifyNotificationShown(notificationType: StreakNotificationType) {
-        val analyticEventCaptor = argumentCaptor<AnalyticEvent>()
-
-        verify(analytic).report(analyticEventCaptor.capture())
+    fun `recent strike less than or equal to zero selects zero streak notification`() {
         assertEquals(
-            notificationType.type,
-            analyticEventCaptor.firstValue.params["type"]
+            StreakNotificationType.ZERO,
+            getStreakNotificationType(recentStrike = 0, solvedToday = 0)
         )
-        verify(stepikNotificationManager).showNotification(eq(STREAK_NOTIFICATION_ID), any())
+        assertEquals(
+            StreakNotificationType.ZERO,
+            getStreakNotificationType(recentStrike = -1, solvedToday = 1)
+        )
     }
 
-    private companion object {
-        const val USER_ID = 1L
-        const val STREAK_NOTIFICATION_ID = 3214L
+    @Test
+    fun `positive recent strike above pins limit with solved today selects improvement notification`() {
+        assertEquals(
+            StreakNotificationType.SOLVED_TODAY,
+            getStreakNotificationType(recentStrike = 381, solvedToday = 1)
+        )
+    }
+
+    @Test
+    fun `positive recent strike above pins limit without solved today selects call to action notification`() {
+        assertEquals(
+            StreakNotificationType.NOT_SOLVED_TODAY,
+            getStreakNotificationType(recentStrike = 380, solvedToday = 0)
+        )
     }
 }

--- a/model/src/main/java/org/stepik/android/model/user/UserActivitySummary.kt
+++ b/model/src/main/java/org/stepik/android/model/user/UserActivitySummary.kt
@@ -1,0 +1,20 @@
+package org.stepik.android.model.user
+
+import com.google.gson.annotations.SerializedName
+
+data class UserActivitySummary(
+    @SerializedName("id")
+    val id: Long = -1,
+    @SerializedName("recent_strike")
+    val recentStrike: Int = 0,
+    @SerializedName("solved_today")
+    val solvedToday: Int = 0,
+    @SerializedName("max_strike")
+    val maxStrike: Int = 0,
+    @SerializedName("solved")
+    val solved: Int = 0,
+    @SerializedName("days")
+    val days: Int = 0,
+    @SerializedName("pins")
+    val pins: List<Long> = emptyList()
+)


### PR DESCRIPTION
**YouTrack task**: [APPS-3853](https://youtrack.stepik.net/issue/APPS-3853/Snyat-ogranichenie-u-streak-v-365-dnej-v-prilozheniyah)

**Description List**:
* Fix incorrect streak display caused by calculating user streak counters from the limited user-activities pins array.
* Use GET /api/user-activity-summaries/{user_id} as described in docs/APPS-3853.md.
* Display current streak from recent_strike, max streak from max_strike, and active/continue state from solved_today > 0.
* Keep pins for activity graph data and leave the old user-activities endpoint/helpers for compatibility.
* Update profile activities, home streak, post-login streak dialog, and streak notifications.
* Add unit coverage for profile activity mapping, long streak summary consumers, and streak notification branching.

**Testing**:
* ./gradlew :app:compileDebugUnitTestKotlin - passed.
* ./gradlew :app:testDebugUnitTest - passed.