### PR TITLE
Fix stories nullable text fields

### DIFF
--- a/app/src/main/java/org/stepic/droid/features/stories/ui/delegate/FeedbackStoryPartDelegate.kt
+++ b/app/src/main/java/org/stepic/droid/features/stories/ui/delegate/FeedbackStoryPartDelegate.kt
@@ -29,13 +29,15 @@ import ru.nobird.android.stories.ui.custom.DismissableLayout
 import ru.nobird.android.stories.ui.custom.StoryView
 import ru.nobird.android.stories.ui.delegate.StoryPartViewDelegate
 import ru.nobird.android.view.base.ui.extension.hideKeyboard
-import ru.nobird.android.view.base.ui.extension.inflate
 
 class FeedbackStoryPartDelegate(
     private val analytic: Analytic,
     private val context: Context,
     private val dismissableLayout: DismissableLayout
 ) : StoryPartViewDelegate() {
+    private companion object {
+        private const val DEFAULT_TEXT_COLOR = "ffffff"
+    }
 
     private val progressDrawable =
         CircularProgressDrawable(context).apply {
@@ -76,9 +78,11 @@ class FeedbackStoryPartDelegate(
 
     private fun setUpText(binding: ViewStoryFeedbackBinding, text: StoryTemplate.Text?) {
         if (text != null) {
-            @ColorInt val textColor = getColorInt(text.textColor)
+            val textColorValue = text.textColor?.takeIf(String::isNotBlank) ?: DEFAULT_TEXT_COLOR
+            @ColorInt val textColor = getColorInt(textColorValue)
             binding.storyTitle.setTextColor(textColor)
             binding.storyTitle.text = text.title
+            binding.storyTitle.isVisible = text.title?.isNotBlank() ?: false
         }
     }
 

--- a/app/src/main/java/org/stepic/droid/features/stories/ui/delegate/PlainTextWithButtonStoryPartDelegate.kt
+++ b/app/src/main/java/org/stepic/droid/features/stories/ui/delegate/PlainTextWithButtonStoryPartDelegate.kt
@@ -33,6 +33,7 @@ class PlainTextWithButtonStoryPartDelegate(
 ) : StoryPartViewDelegate() {
     companion object {
         private const val COLOR_MASK = 0xFF000000.toInt()
+        private const val DEFAULT_TEXT_COLOR = "ffffff"
     }
 
     private val progressDrawable =
@@ -73,12 +74,14 @@ class PlainTextWithButtonStoryPartDelegate(
 
     private fun setUpText(binding: ViewStoryPlainTextWithButtonBinding, text: StoryTemplate.Text?) {
         if (text != null) {
-            @ColorInt val textColor = COLOR_MASK or text.textColor.toInt(16)
+            val textColorValue = text.textColor?.takeIf(String::isNotBlank) ?: DEFAULT_TEXT_COLOR
+            @ColorInt val textColor = COLOR_MASK or textColorValue.toInt(16)
 
             binding.storyTitle.setTextColor(textColor)
             binding.storyText.setTextColor(textColor)
 
             binding.storyTitle.text = text.title
+            binding.storyTitle.isVisible = text.title?.isNotBlank() ?: false
             binding.storyText.text = text.text
             binding.storyText.isVisible = text.text?.isNotBlank() ?: false
         }

--- a/model/src/main/java/org/stepik/android/model/StoryTemplate.kt
+++ b/model/src/main/java/org/stepik/android/model/StoryTemplate.kt
@@ -52,10 +52,10 @@ class StoryTemplate(
             val text: String?,
 
             @SerializedName("text_color")
-            val textColor: String,
+            val textColor: String?,
 
             @SerializedName("title")
-            val title: String
+            val title: String?
     ) : Parcelable {
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeString(backgroundStyle)
@@ -70,8 +70,8 @@ class StoryTemplate(
             override fun createFromParcel(parcel: Parcel) = Text(
                     parcel.readString(),
                     parcel.readString(),
-                    parcel.readString()!!,
-                    parcel.readString()!!
+                    parcel.readString(),
+                    parcel.readString()
             )
 
             override fun newArray(size: Int) =

--- a/model/src/test/java/org/stepik/android/model/StoryTemplateTest.kt
+++ b/model/src/test/java/org/stepik/android/model/StoryTemplateTest.kt
@@ -1,0 +1,58 @@
+package org.stepik.android.model
+
+import android.os.Parcel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StoryTemplateTest {
+    @Test
+    fun storyTextWithMissingTitleAndTextColorIsParcelable() {
+        val storyText = StoryTemplate.Text(
+            backgroundStyle = null,
+            text = "Text",
+            textColor = null,
+            title = null
+        )
+
+        val restoredStoryText = storyText.parcelAndRestore()
+
+        assertNull(restoredStoryText.backgroundStyle)
+        assertEquals(storyText.text, restoredStoryText.text)
+        assertNull(restoredStoryText.textColor)
+        assertNull(restoredStoryText.title)
+    }
+
+    @Test
+    fun storyTextWithTextColorIsParcelable() {
+        val storyText = StoryTemplate.Text(
+            backgroundStyle = null,
+            text = "Text",
+            textColor = "ffffff",
+            title = "Title"
+        )
+
+        val restoredStoryText = storyText.parcelAndRestore()
+
+        assertNull(restoredStoryText.backgroundStyle)
+        assertEquals(storyText.text, restoredStoryText.text)
+        assertEquals(storyText.textColor, restoredStoryText.textColor)
+        assertEquals(storyText.title, restoredStoryText.title)
+    }
+
+    private fun StoryTemplate.Text.parcelAndRestore(): StoryTemplate.Text {
+        val parcel = Parcel.obtain()
+
+        try {
+            writeToParcel(parcel, 0)
+            parcel.setDataPosition(0)
+
+            return StoryTemplate.Text.CREATOR.createFromParcel(parcel)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Make story text title and text color nullable in the model/parcelling
- Hide missing story titles and use white as the default text color when text_color is absent
- Add parceling coverage for missing and present story text color

## Tests
- ./gradlew :model:testDebugUnitTest --tests org.stepik.android.model.StoryTemplateTest
- ./gradlew :app:compileDebugKotlin